### PR TITLE
chore: add .envrc to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+.envrc


### PR DESCRIPTION
Prevent .envrc (direnv secrets) from being committed.