### PR TITLE
Refresh README and add MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Jeff DiTeodoro
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
 # tp
 
-A directory teleportation tool for the terminal. Navigate to bookmarked directories instantly, with special support for git worktrees.
+[![CI](https://github.com/jeffdt/teleport/actions/workflows/ci.yml/badge.svg)](https://github.com/jeffdt/teleport/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![Built with Rust](https://img.shields.io/badge/built%20with-Rust-orange.svg)](https://www.rust-lang.org)
 
-## What it does
+A directory teleportation tool for the terminal. Create portals in your favorite directories and jump to them instantly, with built-in git worktree support.
 
-`tp` manages two kinds of bookmarks:
-
-- **Portals**: fixed destinations (absolute paths). `tp app` always takes you to `~/r/app`.
-- **Tunnels**: repo-relative destinations that resolve through git worktrees. `tp is` takes you to `python/klaviyo/.../insights_service` inside whichever worktree of k-repo you're currently in (or lets you pick one if you're not in any).
+> **Heads up:** tp is under active development. Commands, config format, and behavior may change without notice, and there are no guarantees of backwards compatibility between versions. Once the core workflow settles, stability will be prioritized.
 
 ## Install
 
@@ -27,32 +26,22 @@ cp shell/tp.zsh ~/your/shell/config/tp.zsh
 ## Usage
 
 ```bash
-tp app          # teleport to a portal
-tp is           # teleport to a tunnel (picks worktree if needed)
-tp              # fzf picker over all bookmarks
-tp -c app       # teleport then open Claude
-tp add myplace  # bookmark current directory (auto-detects portal vs tunnel)
-tp rm myplace   # remove a bookmark
-tp ls           # list all bookmarks
+tp blog         # teleport to a portal by exact name
+tp dot          # substring match: jumps directly if one match, picker if multiple
+tp              # fzf picker over all portals
+tp -m blog      # skip worktree picker, go straight to main worktree
+tp -c blog      # teleport then open Claude Code
+tp add myplace  # create a portal from current directory
+tp rm myplace   # remove a portal
+tp ls           # list all portals
 tp edit         # open config in $EDITOR
 ```
 
-## How `tp add` works
+## Worktree support
 
-- Outside a git repo: creates a portal (absolute path)
-- At a git repo root: creates a portal (absolute path)
-- Inside a git repo subdir: creates a tunnel (repo-relative path)
-- `tp add --abs <name>`: forces a portal regardless of context
+If a portal points inside a git repo that has multiple worktrees, tp shows an fzf picker so you can choose which worktree to resolve through. The current worktree is pre-selected at the top, with colored `(current)` and `(main)` labels. If the repo has only one worktree, tp goes there directly.
 
-## How tunnels resolve
-
-When you `tp` to a tunnel:
-
-1. If you're already inside a worktree of that repo, it uses that worktree
-2. If the repo has only one worktree, it goes there directly
-3. If the repo has multiple worktrees, it shows an fzf picker
-
-Worktree discovery uses `git worktree list`, so it works with any worktree layout (sibling dirs, subdirectories, bare repo setups).
+Use `-m` to skip the picker and always land in the main worktree.
 
 ## Config
 
@@ -60,14 +49,11 @@ Stored at `~/.config/tp/portals.toml`:
 
 ```toml
 [portals]
-app = "~/r/app"
-shell = "~/shell"
-
-[tunnels.is]
-repo = "~/r/k-repo"
-path = "python/klaviyo/executive_business_report/insights_service"
+dotfiles = "~/dotfiles"
+blog = "~/projects/blog"
+notes = "~/Documents/notes"
 ```
 
 ## How it works
 
-`tp` is a thin zsh function that calls `warp-core` (the Rust binary). The binary handles all logic and outputs a `cd:/path/to/dir` directive. The shell function interprets it and executes the `cd`. This split is necessary because a subprocess cannot change the parent shell's working directory.
+`tp` is a zsh function that calls `warp-core` (the Rust binary). The binary handles config, path resolution, worktree discovery, and fzf integration, then outputs a `cd:/path` directive. The shell function interprets it and runs `cd`. This split exists because a subprocess cannot change the parent shell's working directory.


### PR DESCRIPTION
The README had gone stale: it documented tunnels (removed), referenced Klaviyo-specific paths, and mixed "bookmark" and "portal" terminology. This rewrites it to match the current codebase, adds the substring matching feature that was undocumented, swaps in generic examples, and adds an active-development warning so people know what they're getting into. Also adds an MIT license and restores the CI/license/Rust badges.