### PR TITLE
chore: gitignore CLAUDE.local.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 .envrc
+CLAUDE.local.md


### PR DESCRIPTION
## Summary
- Adds `CLAUDE.local.md` to `.gitignore` so `wt step copy-ignored` copies it to new worktrees automatically

## Test plan
- [x] `wt switch --create <branch>` copies `CLAUDE.local.md` to the new worktree

🤖 Generated with [Claude Code](https://claude.com/claude-code)