### PR TITLE
Add prune command to find and remove broken portals

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,7 @@ Two components:
 ```bash
 source "$HOME/.cargo/env"
 cargo build                    # build
+cargo run -- <args>            # test warp-core without installing (avoids worktree binary collisions)
 cargo install --path .         # install to ~/.cargo/bin/
 cp shell/tp.zsh ~/shell/common/tp.zsh  # update shell wrapper
 ```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,6 +53,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "bitflags"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -141,6 +153,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -149,6 +183,28 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
 ]
 
 [[package]]
@@ -164,13 +220,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "indexmap"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -178,6 +242,18 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -195,10 +271,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -211,6 +305,16 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -231,15 +335,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.17",
  "libredox",
  "thiserror",
 ]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -272,6 +401,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -295,6 +437,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]
@@ -365,6 +520,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -378,6 +539,7 @@ dependencies = [
  "clap_complete",
  "dirs",
  "serde",
+ "tempfile",
  "toml",
 ]
 
@@ -386,6 +548,58 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
 
 [[package]]
 name = "windows-link"
@@ -410,3 +624,97 @@ checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,6 @@ clap_complete = "4"
 serde = { version = "1", features = ["derive"] }
 toml = "0.8"
 dirs = "6"
+
+[dev-dependencies]
+tempfile = "3"

--- a/src/config.rs
+++ b/src/config.rs
@@ -61,14 +61,16 @@ mod tests {
     #[test]
     fn broken_portals_finds_missing_dirs() {
         let existing = tempfile::tempdir().unwrap();
-        let missing_path = "/tmp/tp-test-nonexistent-dir-abc123";
+        let gone = tempfile::tempdir().unwrap();
+        let missing_path = gone.path().display().to_string();
+        drop(gone);
 
         let mut config = Config::default();
         config.add_portal(
             "good".to_string(),
             format!("{}", existing.path().display()),
         );
-        config.add_portal("bad".to_string(), missing_path.to_string());
+        config.add_portal("bad".to_string(), missing_path.clone());
 
         let broken = config.broken_portals();
         assert_eq!(broken.len(), 1);

--- a/src/config.rs
+++ b/src/config.rs
@@ -43,4 +43,67 @@ impl Config {
     pub fn remove(&mut self, name: &str) -> bool {
         self.portals.remove(name).is_some()
     }
+
+    pub fn broken_portals(&self) -> Vec<(String, String)> {
+        self.portals
+            .iter()
+            .filter(|(_, path)| !crate::resolve::expand_tilde(path).is_dir())
+            .map(|(name, path)| (name.clone(), path.clone()))
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn broken_portals_finds_missing_dirs() {
+        let existing = tempfile::tempdir().unwrap();
+        let missing_path = "/tmp/tp-test-nonexistent-dir-abc123";
+
+        let mut config = Config::default();
+        config.add_portal(
+            "good".to_string(),
+            format!("{}", existing.path().display()),
+        );
+        config.add_portal("bad".to_string(), missing_path.to_string());
+
+        let broken = config.broken_portals();
+        assert_eq!(broken.len(), 1);
+        assert_eq!(broken[0].0, "bad");
+        assert_eq!(broken[0].1, missing_path);
+    }
+
+    #[test]
+    fn broken_portals_empty_when_all_valid() {
+        let existing = tempfile::tempdir().unwrap();
+
+        let mut config = Config::default();
+        config.add_portal(
+            "good".to_string(),
+            format!("{}", existing.path().display()),
+        );
+
+        let broken = config.broken_portals();
+        assert!(broken.is_empty());
+    }
+
+    #[test]
+    fn broken_portals_detects_file_not_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("not-a-dir");
+        fs::write(&file_path, "i am a file").unwrap();
+
+        let mut config = Config::default();
+        config.add_portal(
+            "file-portal".to_string(),
+            format!("{}", file_path.display()),
+        );
+
+        let broken = config.broken_portals();
+        assert_eq!(broken.len(), 1);
+        assert_eq!(broken[0].0, "file-portal");
+    }
 }

--- a/src/fzf.rs
+++ b/src/fzf.rs
@@ -92,6 +92,15 @@ fn strip_ansi(s: &str) -> String {
     result
 }
 
+/// Format broken portal entries for prune output. Returns display lines with aligned columns.
+pub fn format_prune_entries(portals: &[(String, String)]) -> Vec<String> {
+    let name_width = portals.iter().map(|(n, _)| n.len()).max().unwrap_or(0);
+    portals
+        .iter()
+        .map(|(name, path)| format!("  {:<width$}  {}", name, path, width = name_width))
+        .collect()
+}
+
 /// Spawn fzf with the given lines and prompt. Returns the index of the selected line or None.
 pub fn pick(lines: &[String], prompt: &str) -> Option<usize> {
     let fzf = Command::new("fzf")
@@ -242,5 +251,27 @@ mod tests {
 
         let entries = format_worktree_entries(&worktrees);
         assert!(entries[0].0.contains("(current, main)"));
+    }
+
+    #[test]
+    fn format_prune_entries_aligns_columns() {
+        let portals = vec![
+            ("short".to_string(), "~/a".to_string()),
+            ("much-longer".to_string(), "~/b".to_string()),
+        ];
+
+        let lines = format_prune_entries(&portals);
+        assert_eq!(lines.len(), 2);
+        // Both paths should start at the same column
+        let pos_a = lines[0].find("~/a").unwrap();
+        let pos_b = lines[1].find("~/b").unwrap();
+        assert_eq!(pos_a, pos_b);
+    }
+
+    #[test]
+    fn format_prune_entries_empty() {
+        let portals: Vec<(String, String)> = vec![];
+        let lines = format_prune_entries(&portals);
+        assert!(lines.is_empty());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -237,15 +237,16 @@ fn cmd_prune(config: &mut Config, force: bool) {
     }
 
     let lines = fzf::format_prune_entries(&broken);
+    let noun = if broken.len() == 1 { "portal" } else { "portals" };
 
     if force {
         for (name, _) in &broken {
             config.remove(name);
         }
         config.save();
-        println!("Removed {} broken {}:", broken.len(), if broken.len() == 1 { "portal" } else { "portals" });
+        println!("Removed {} broken {}:", broken.len(), noun);
     } else {
-        println!("Found {} broken {}:", broken.len(), if broken.len() == 1 { "portal" } else { "portals" });
+        println!("Found {} broken {}:", broken.len(), noun);
     }
 
     for line in &lines {

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,6 +66,12 @@ enum Commands {
     Completions {
         shell: Shell,
     },
+    /// Find and remove broken portals
+    Prune {
+        /// Actually remove broken portals (default is dry-run)
+        #[arg(short = 'f', long = "force")]
+        force: bool,
+    },
 }
 
 fn emit_cd_or_exit(name: &str, target: std::path::PathBuf) {
@@ -194,7 +200,7 @@ fn cmd_pick(config: &Config) {
     }
 }
 
-const RESERVED_NAMES: &[&str] = &["add", "rm", "ls", "edit", "help", "completions"];
+const RESERVED_NAMES: &[&str] = &["add", "rm", "ls", "edit", "help", "completions", "prune"];
 
 fn cmd_add(config: &mut Config, name: String) {
     if RESERVED_NAMES.contains(&name.as_str()) {
@@ -222,6 +228,35 @@ fn cmd_rm(config: &mut Config, name: String) {
     }
 }
 
+fn cmd_prune(config: &mut Config, force: bool) {
+    let broken = config.broken_portals();
+
+    if broken.is_empty() {
+        println!("All portals are valid.");
+        return;
+    }
+
+    let lines = fzf::format_prune_entries(&broken);
+
+    if force {
+        for (name, _) in &broken {
+            config.remove(name);
+        }
+        config.save();
+        println!("Removed {} broken {}:", broken.len(), if broken.len() == 1 { "portal" } else { "portals" });
+    } else {
+        println!("Found {} broken {}:", broken.len(), if broken.len() == 1 { "portal" } else { "portals" });
+    }
+
+    for line in &lines {
+        println!("{}", line);
+    }
+
+    if !force {
+        println!("Run 'tp prune -f' to remove them.");
+    }
+}
+
 fn cmd_ls(config: &Config) {
     if config.portals.is_empty() {
         println!("No portals configured. Use 'tp add <name>' to create one.");
@@ -243,6 +278,7 @@ fn main() {
         Some(Commands::Add { name }) => cmd_add(&mut config, name),
         Some(Commands::Rm { name }) => cmd_rm(&mut config, name),
         Some(Commands::Ls) => cmd_ls(&config),
+        Some(Commands::Prune { force }) => cmd_prune(&mut config, force),
         Some(Commands::Completions { shell }) => {
             let mut cmd = Cli::command();
             generate(shell, &mut cmd, "warp-core", &mut std::io::stdout());


### PR DESCRIPTION
Closes #12

Adds `tp prune` (dry-run by default) that scans all portals and reports which ones point to directories that no longer exist. With `-f`, it removes them from the config. A portal is considered "broken" if its expanded path fails `is_dir()`, covering both missing directories and paths that exist but aren't directories.

Designed as a subcommand for now; will convert to `tp -p` / `tp -pf` flags once #8 lands.