### PR TITLE
Replace subcommands with flags

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ Directory teleportation tool with worktree-aware bookmarks called **portals**.
 Two components:
 
 - **`warp-core`** (Rust binary): handles config parsing, path resolution, worktree discovery, fzf integration. Outputs directives to stdout: `cd:<path>` (shell should cd) or plain text (shell should print). Never calls `cd` itself.
-- **`tp`** (zsh function in `shell/tp.zsh`): calls `warp-core`, interprets directives, executes `cd`. Handles `-c` flag (open Claude after teleporting) and `edit` subcommand.
+- **`tp`** (zsh function in `shell/tp.zsh`): calls `warp-core`, interprets directives (`cd:`, `cd+c:`, `edit:`), executes shell-level actions. Pure dispatcher with no logic of its own.
 
 ## Key concepts
 
@@ -20,22 +20,22 @@ Two components:
 
 | File | Responsibility |
 |---|---|
-| `src/main.rs` | CLI definition (clap), subcommand dispatch, substring matching |
+| `src/main.rs` | CLI definition (clap), flag dispatch, substring matching |
 | `src/config.rs` | TOML types (Config), load/save, add/remove |
 | `src/resolve.rs` | Tilde expansion, git worktree list, portal worktree context, detect_add_context |
 | `src/fzf.rs` | Format table rows, spawn fzf subprocess (ANSI-aware, index-based matching), parse selection |
-| `shell/tp.zsh` | Shell wrapper + zsh tab completion |
+| `shell/tp.zsh` | Shell directive dispatcher + zsh tab completion |
 
 ## Commands
 
 - `tp <query>` teleport to portal by exact name or substring match (with worktree picker if multiple worktrees)
-- `tp -m <name>` teleport to main worktree (skip picker)
 - `tp` (no args) fzf picker
-- `tp add <name>` create portal from cwd
-- `tp rm <name>` remove
-- `tp ls` list all
-- `tp edit` open config in $EDITOR
-- `tp -c <name>` teleport then open Claude (composes with -m)
+- `tp -a [name]` add portal for cwd (auto-names from directory basename if name omitted)
+- `tp -r [name]` remove portal (by name, or by cwd match if name omitted)
+- `tp -l` list all portals
+- `tp -e` open config in $EDITOR
+- `tp -m <query>` teleport to main worktree (skip picker)
+- `tp -c <query>` teleport then open Claude (composes with -m)
 
 ## Development
 

--- a/shell/tp.zsh
+++ b/shell/tp.zsh
@@ -1,28 +1,12 @@
 tp() {
-  if [[ "$1" == "edit" ]]; then
-    ${EDITOR:-vim} ~/.config/tp/portals.toml
-    return
-  fi
-
-  local claude=false
-  local args=()
-  for arg in "$@"; do
-    if [[ "$arg" == "-c" || "$arg" == "--claude" ]]; then
-      claude=true
-    else
-      args+=("$arg")
-    fi
-  done
-
-  local result=$(warp-core "${args[@]}")
+  local result=$(warp-core "$@")
   local rc=$?
 
   case "$result" in
-    cd:*)
-      cd "${result#cd:}"
-      $claude && claude
-      ;;
-    *) [[ -n "$result" ]] && echo "$result" ;;
+    cd+c:*) cd "${result#cd+c:}" && claude ;;
+    cd:*)   cd "${result#cd:}" ;;
+    edit:*) ${EDITOR:-vim} "${result#edit:}" ;;
+    *)      [[ -n "$result" ]] && echo "$result" ;;
   esac
 
   return $rc
@@ -31,7 +15,7 @@ tp() {
 _tp() {
   local -a names
   if [[ -f ~/.config/tp/portals.toml ]]; then
-    names=($(warp-core ls 2>/dev/null | awk '{print $1}'))
+    names=($(warp-core -l 2>/dev/null | awk '{print $1}'))
   fi
   _describe 'portal' names
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -198,6 +198,8 @@ fn cmd_add(config: &mut Config, name: Option<String>) {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+
     #[test]
     fn auto_name_from_basename() {
         let path = "/Users/jeff/code/teleport";
@@ -219,15 +221,90 @@ mod tests {
             .unwrap();
         assert_eq!(name, "sub");
     }
+
+    #[test]
+    fn find_portal_by_path_single_match() {
+        let mut config = Config::default();
+        config.portals.insert("myproject".to_string(), "~/code/myproject".to_string());
+        config.portals.insert("notes".to_string(), "~/Documents/notes".to_string());
+
+        let cwd = resolve::expand_tilde("~/code/myproject");
+        let matches: Vec<_> = config
+            .portals
+            .iter()
+            .filter(|(_, path)| resolve::expand_tilde(path) == cwd)
+            .collect();
+
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].0, "myproject");
+    }
+
+    #[test]
+    fn find_portal_by_path_no_match() {
+        let mut config = Config::default();
+        config.portals.insert("notes".to_string(), "~/Documents/notes".to_string());
+
+        let cwd = resolve::expand_tilde("~/code/other");
+        let matches: Vec<_> = config
+            .portals
+            .iter()
+            .filter(|(_, path)| resolve::expand_tilde(path) == cwd)
+            .collect();
+
+        assert_eq!(matches.len(), 0);
+    }
+
+    #[test]
+    fn find_portal_by_path_multiple_matches() {
+        let mut config = Config::default();
+        config.portals.insert("proj".to_string(), "~/code/myproject".to_string());
+        config.portals.insert("proj2".to_string(), "~/code/myproject".to_string());
+
+        let cwd = resolve::expand_tilde("~/code/myproject");
+        let matches: Vec<_> = config
+            .portals
+            .iter()
+            .filter(|(_, path)| resolve::expand_tilde(path) == cwd)
+            .collect();
+
+        assert_eq!(matches.len(), 2);
+    }
 }
 
 fn cmd_rm(config: &mut Config, name: Option<String>) {
-    let name = name.expect("Portal name required for rm");
+    let name = match name {
+        Some(n) => n,
+        None => {
+            let cwd = std::env::current_dir().expect("could not determine current directory");
+            let matches: Vec<_> = config
+                .portals
+                .iter()
+                .filter(|(_, path)| resolve::expand_tilde(path) == cwd)
+                .map(|(name, _)| name.clone())
+                .collect();
+
+            match matches.len() {
+                0 => {
+                    eprintln!("No portal points to this directory");
+                    process::exit(1);
+                }
+                1 => matches.into_iter().next().unwrap(),
+                _ => {
+                    eprintln!(
+                        "Multiple portals point to this directory: {}. Specify which one with 'tp -r <name>'.",
+                        matches.join(", ")
+                    );
+                    process::exit(1);
+                }
+            }
+        }
+    };
+
     if config.remove(&name) {
         config.save();
-        println!("Removed '{}'", name);
+        println!("Removed portal '{}'", name);
     } else {
-        eprintln!("'{}' not found", name);
+        eprintln!("Portal '{}' not found", name);
         process::exit(1);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,36 +13,36 @@ use resolve::{portal_worktree_context, sorted_worktrees};
 #[derive(Parser)]
 #[command(name = "warp-core", version, about = "Engine for tp (teleport)")]
 struct Cli {
-    #[command(subcommand)]
-    command: Option<Commands>,
+    /// Add a portal for the current directory
+    #[arg(short = 'a', long = "add", conflicts_with_all = ["remove", "list", "edit", "completions"])]
+    add: bool,
+
+    /// Remove a portal
+    #[arg(short = 'r', long = "rm", conflicts_with_all = ["add", "list", "edit", "completions"])]
+    remove: bool,
+
+    /// List all portals
+    #[arg(short = 'l', long = "ls", conflicts_with_all = ["add", "remove", "edit", "completions"])]
+    list: bool,
+
+    /// Open config in editor
+    #[arg(short = 'e', long = "edit", conflicts_with_all = ["add", "remove", "list", "completions"])]
+    edit: bool,
 
     /// Skip worktree picker, go to main worktree
     #[arg(short = 'm', long = "main")]
     main_worktree: bool,
 
-    /// Portal name to teleport to
-    name: Option<String>,
-}
+    /// Open Claude after teleporting
+    #[arg(short = 'c', long = "claude")]
+    claude: bool,
 
-#[derive(clap::Subcommand)]
-enum Commands {
-    /// Create a portal from the current directory
-    Add {
-        /// Name for the new portal
-        name: String,
-    },
-    /// Remove a portal
-    Rm {
-        /// Name to remove
-        name: String,
-    },
-    /// List all portals
-    Ls,
-    /// Generate shell completions (hidden)
-    #[command(hide = true)]
-    Completions {
-        shell: Shell,
-    },
+    /// Generate shell completions
+    #[arg(long = "completions", conflicts_with_all = ["add", "remove", "list", "edit"])]
+    completions: Option<Shell>,
+
+    /// Portal name or teleport query
+    name: Option<String>,
 }
 
 fn emit_cd_or_exit(name: &str, target: std::path::PathBuf) {
@@ -110,7 +110,7 @@ fn find_matching_portals<'a>(config: &'a Config, query: &str) -> Vec<(&'a String
         .collect()
 }
 
-fn cmd_teleport(config: &Config, query: &str, main_only: bool) {
+fn cmd_teleport(config: &Config, query: &str, main_only: bool, _claude: bool) {
     if let Some(path) = config.portals.get(query) {
         teleport_to_portal(query, path, main_only);
         return;
@@ -167,13 +167,8 @@ fn cmd_pick(config: &Config) {
     }
 }
 
-const RESERVED_NAMES: &[&str] = &["add", "rm", "ls", "edit", "help", "completions"];
-
-fn cmd_add(config: &mut Config, name: String) {
-    if RESERVED_NAMES.contains(&name.as_str()) {
-        eprintln!("'{}' is a reserved command name", name);
-        process::exit(1);
-    }
+fn cmd_add(config: &mut Config, name: Option<String>) {
+    let name = name.expect("Portal name required for add");
     if config.portals.contains_key(&name) {
         eprintln!("'{}' already exists. Remove it first with 'tp rm {}'.", name, name);
         process::exit(1);
@@ -185,7 +180,8 @@ fn cmd_add(config: &mut Config, name: String) {
     println!("Added portal '{}'", name);
 }
 
-fn cmd_rm(config: &mut Config, name: String) {
+fn cmd_rm(config: &mut Config, name: Option<String>) {
+    let name = name.expect("Portal name required for rm");
     if config.remove(&name) {
         config.save();
         println!("Removed '{}'", name);
@@ -193,6 +189,10 @@ fn cmd_rm(config: &mut Config, name: String) {
         eprintln!("'{}' not found", name);
         process::exit(1);
     }
+}
+
+fn cmd_edit() {
+    println!("edit:{}", Config::path().display());
 }
 
 fn cmd_ls(config: &Config) {
@@ -212,20 +212,20 @@ fn main() {
 
     let mut config = Config::load();
 
-    match cli.command {
-        Some(Commands::Add { name }) => cmd_add(&mut config, name),
-        Some(Commands::Rm { name }) => cmd_rm(&mut config, name),
-        Some(Commands::Ls) => cmd_ls(&config),
-        Some(Commands::Completions { shell }) => {
-            let mut cmd = Cli::command();
-            generate(shell, &mut cmd, "warp-core", &mut std::io::stdout());
-        }
-        None => {
-            if let Some(name) = cli.name {
-                cmd_teleport(&config, &name, cli.main_worktree);
-            } else {
-                cmd_pick(&config);
-            }
-        }
+    if let Some(shell) = cli.completions {
+        let mut cmd = Cli::command();
+        generate(shell, &mut cmd, "warp-core", &mut std::io::stdout());
+    } else if cli.add {
+        cmd_add(&mut config, cli.name);
+    } else if cli.remove {
+        cmd_rm(&mut config, cli.name);
+    } else if cli.list {
+        cmd_ls(&config);
+    } else if cli.edit {
+        cmd_edit();
+    } else if let Some(name) = cli.name {
+        cmd_teleport(&config, &name, cli.main_worktree, cli.claude);
+    } else {
+        cmd_pick(&config);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,11 +30,11 @@ struct Cli {
     edit: bool,
 
     /// Skip worktree picker, go to main worktree
-    #[arg(short = 'm', long = "main")]
+    #[arg(short = 'm', long = "main", conflicts_with_all = ["add", "remove", "list", "edit", "completions"])]
     main_worktree: bool,
 
     /// Open Claude after teleporting
-    #[arg(short = 'c', long = "claude")]
+    #[arg(short = 'c', long = "claude", conflicts_with_all = ["add", "remove", "list", "edit", "completions"])]
     claude: bool,
 
     /// Generate shell completions
@@ -197,81 +197,6 @@ fn cmd_add(config: &mut Config, name: Option<String>) {
     println!("Added portal '{}'", name);
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn auto_name_from_basename() {
-        let path = "/Users/jeff/code/teleport";
-        let name = std::path::Path::new(path)
-            .file_name()
-            .unwrap()
-            .to_str()
-            .unwrap();
-        assert_eq!(name, "teleport");
-    }
-
-    #[test]
-    fn auto_name_from_basename_nested() {
-        let path = "/Users/jeff/code/my-project/sub";
-        let name = std::path::Path::new(path)
-            .file_name()
-            .unwrap()
-            .to_str()
-            .unwrap();
-        assert_eq!(name, "sub");
-    }
-
-    #[test]
-    fn find_portal_by_path_single_match() {
-        let mut config = Config::default();
-        config.portals.insert("myproject".to_string(), "~/code/myproject".to_string());
-        config.portals.insert("notes".to_string(), "~/Documents/notes".to_string());
-
-        let cwd = resolve::expand_tilde("~/code/myproject");
-        let matches: Vec<_> = config
-            .portals
-            .iter()
-            .filter(|(_, path)| resolve::expand_tilde(path) == cwd)
-            .collect();
-
-        assert_eq!(matches.len(), 1);
-        assert_eq!(matches[0].0, "myproject");
-    }
-
-    #[test]
-    fn find_portal_by_path_no_match() {
-        let mut config = Config::default();
-        config.portals.insert("notes".to_string(), "~/Documents/notes".to_string());
-
-        let cwd = resolve::expand_tilde("~/code/other");
-        let matches: Vec<_> = config
-            .portals
-            .iter()
-            .filter(|(_, path)| resolve::expand_tilde(path) == cwd)
-            .collect();
-
-        assert_eq!(matches.len(), 0);
-    }
-
-    #[test]
-    fn find_portal_by_path_multiple_matches() {
-        let mut config = Config::default();
-        config.portals.insert("proj".to_string(), "~/code/myproject".to_string());
-        config.portals.insert("proj2".to_string(), "~/code/myproject".to_string());
-
-        let cwd = resolve::expand_tilde("~/code/myproject");
-        let matches: Vec<_> = config
-            .portals
-            .iter()
-            .filter(|(_, path)| resolve::expand_tilde(path) == cwd)
-            .collect();
-
-        assert_eq!(matches.len(), 2);
-    }
-}
-
 fn cmd_rm(config: &mut Config, name: Option<String>) {
     let name = match name {
         Some(n) => n,
@@ -346,5 +271,80 @@ fn main() {
         cmd_teleport(&config, &name, cli.main_worktree, cli.claude);
     } else {
         cmd_pick(&config);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn auto_name_from_basename() {
+        let path = "/Users/jeff/code/teleport";
+        let name = std::path::Path::new(path)
+            .file_name()
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert_eq!(name, "teleport");
+    }
+
+    #[test]
+    fn auto_name_from_basename_nested() {
+        let path = "/Users/jeff/code/my-project/sub";
+        let name = std::path::Path::new(path)
+            .file_name()
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert_eq!(name, "sub");
+    }
+
+    #[test]
+    fn find_portal_by_path_single_match() {
+        let mut config = Config::default();
+        config.portals.insert("myproject".to_string(), "~/code/myproject".to_string());
+        config.portals.insert("notes".to_string(), "~/Documents/notes".to_string());
+
+        let cwd = resolve::expand_tilde("~/code/myproject");
+        let matches: Vec<_> = config
+            .portals
+            .iter()
+            .filter(|(_, path)| resolve::expand_tilde(path) == cwd)
+            .collect();
+
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].0, "myproject");
+    }
+
+    #[test]
+    fn find_portal_by_path_no_match() {
+        let mut config = Config::default();
+        config.portals.insert("notes".to_string(), "~/Documents/notes".to_string());
+
+        let cwd = resolve::expand_tilde("~/code/other");
+        let matches: Vec<_> = config
+            .portals
+            .iter()
+            .filter(|(_, path)| resolve::expand_tilde(path) == cwd)
+            .collect();
+
+        assert_eq!(matches.len(), 0);
+    }
+
+    #[test]
+    fn find_portal_by_path_multiple_matches() {
+        let mut config = Config::default();
+        config.portals.insert("proj".to_string(), "~/code/myproject".to_string());
+        config.portals.insert("proj2".to_string(), "~/code/myproject".to_string());
+
+        let cwd = resolve::expand_tilde("~/code/myproject");
+        let matches: Vec<_> = config
+            .portals
+            .iter()
+            .filter(|(_, path)| resolve::expand_tilde(path) == cwd)
+            .collect();
+
+        assert_eq!(matches.len(), 2);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,16 +45,17 @@ struct Cli {
     name: Option<String>,
 }
 
-fn emit_cd_or_exit(name: &str, target: std::path::PathBuf) {
+fn emit_cd_or_exit(name: &str, target: std::path::PathBuf, claude: bool) {
     if !target.exists() {
         eprintln!("Portal '{}' target does not exist: {}", name, target.display());
         process::exit(1);
     }
-    println!("cd:{}", target.display());
+    let prefix = if claude { "cd+c" } else { "cd" };
+    println!("{}:{}", prefix, target.display());
 }
 
 /// Teleport to a known portal by name, handling worktree resolution.
-fn teleport_to_portal(name: &str, path: &str, main_only: bool) {
+fn teleport_to_portal(name: &str, path: &str, main_only: bool, claude: bool) {
     match portal_worktree_context(path) {
         Some(ctx) if ctx.worktrees.len() > 1 => {
             let worktree_root = if main_only {
@@ -80,7 +81,7 @@ fn teleport_to_portal(name: &str, path: &str, main_only: bool) {
             } else {
                 worktree_root.join(&ctx.relative_path)
             };
-            emit_cd_or_exit(name, target);
+            emit_cd_or_exit(name, target, claude);
         }
         Some(ctx) if ctx.worktrees.len() == 1 => {
             let wt = ctx.worktrees.into_iter().next().unwrap();
@@ -89,10 +90,10 @@ fn teleport_to_portal(name: &str, path: &str, main_only: bool) {
             } else {
                 wt.join(&ctx.relative_path)
             };
-            emit_cd_or_exit(name, target);
+            emit_cd_or_exit(name, target, claude);
         }
         _ => {
-            emit_cd_or_exit(name, resolve::resolve_portal(path));
+            emit_cd_or_exit(name, resolve::resolve_portal(path), claude);
         }
     }
 }
@@ -110,9 +111,9 @@ fn find_matching_portals<'a>(config: &'a Config, query: &str) -> Vec<(&'a String
         .collect()
 }
 
-fn cmd_teleport(config: &Config, query: &str, main_only: bool, _claude: bool) {
+fn cmd_teleport(config: &Config, query: &str, main_only: bool, claude: bool) {
     if let Some(path) = config.portals.get(query) {
-        teleport_to_portal(query, path, main_only);
+        teleport_to_portal(query, path, main_only, claude);
         return;
     }
 
@@ -125,7 +126,7 @@ fn cmd_teleport(config: &Config, query: &str, main_only: bool, _claude: bool) {
         }
         1 => {
             let (name, path) = matches[0];
-            teleport_to_portal(name, path, main_only);
+            teleport_to_portal(name, path, main_only, claude);
         }
         _ => {
             let filtered: std::collections::BTreeMap<String, String> = matches
@@ -139,7 +140,7 @@ fn cmd_teleport(config: &Config, query: &str, main_only: bool, _claude: bool) {
                 Some(idx) => {
                     let name = &entries[idx].1;
                     let path = config.portals.get(name).unwrap();
-                    teleport_to_portal(name, path, main_only);
+                    teleport_to_portal(name, path, main_only, claude);
                 }
                 None => process::exit(130),
             }
@@ -151,7 +152,7 @@ fn cmd_pick(config: &Config) {
     let entries = fzf::format_portal_entries(&config.portals, "* ");
 
     if entries.is_empty() {
-        eprintln!("No portals configured. Use 'tp add <name>' to create one.");
+        eprintln!("No portals configured. Use 'tp -a <name>' to create one.");
         process::exit(1);
     }
 
@@ -161,7 +162,7 @@ fn cmd_pick(config: &Config) {
         Some(idx) => {
             let name = &entries[idx].1;
             let path = config.portals.get(name).unwrap();
-            teleport_to_portal(name, path, false);
+            teleport_to_portal(name, path, false, false);
         }
         None => process::exit(130),
     }
@@ -315,7 +316,7 @@ fn cmd_edit() {
 
 fn cmd_ls(config: &Config) {
     if config.portals.is_empty() {
-        println!("No portals configured. Use 'tp add <name>' to create one.");
+        println!("No portals configured. Use 'tp -a <name>' to create one.");
         return;
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -169,18 +169,16 @@ fn cmd_pick(config: &Config) {
 }
 
 fn cmd_add(config: &mut Config, name: Option<String>) {
+    let cwd = std::env::current_dir().expect("could not determine current directory");
+
     let name = match name {
         Some(n) => n,
-        None => {
-            let cwd = std::env::current_dir().expect("could not determine current directory");
-            let basename = cwd
-                .file_name()
-                .expect("current directory has no name")
-                .to_str()
-                .expect("directory name is not valid UTF-8")
-                .to_string();
-            basename
-        }
+        None => cwd
+            .file_name()
+            .expect("current directory has no name")
+            .to_str()
+            .expect("directory name is not valid UTF-8")
+            .to_string(),
     };
 
     if config.portals.contains_key(&name) {
@@ -191,7 +189,7 @@ fn cmd_add(config: &mut Config, name: Option<String>) {
         process::exit(1);
     }
 
-    let path = resolve::detect_add_context();
+    let path = resolve::collapse_tilde(&cwd);
     config.add_portal(name.clone(), path);
     config.save();
     println!("Added portal '{}'", name);

--- a/src/main.rs
+++ b/src/main.rs
@@ -168,9 +168,25 @@ fn cmd_pick(config: &Config) {
 }
 
 fn cmd_add(config: &mut Config, name: Option<String>) {
-    let name = name.expect("Portal name required for add");
+    let name = match name {
+        Some(n) => n,
+        None => {
+            let cwd = std::env::current_dir().expect("could not determine current directory");
+            let basename = cwd
+                .file_name()
+                .expect("current directory has no name")
+                .to_str()
+                .expect("directory name is not valid UTF-8")
+                .to_string();
+            basename
+        }
+    };
+
     if config.portals.contains_key(&name) {
-        eprintln!("'{}' already exists. Remove it first with 'tp rm {}'.", name, name);
+        eprintln!(
+            "Portal '{}' already exists. Use 'tp -a <name>' to specify a different name.",
+            name
+        );
         process::exit(1);
     }
 
@@ -178,6 +194,31 @@ fn cmd_add(config: &mut Config, name: Option<String>) {
     config.add_portal(name.clone(), path);
     config.save();
     println!("Added portal '{}'", name);
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn auto_name_from_basename() {
+        let path = "/Users/jeff/code/teleport";
+        let name = std::path::Path::new(path)
+            .file_name()
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert_eq!(name, "teleport");
+    }
+
+    #[test]
+    fn auto_name_from_basename_nested() {
+        let path = "/Users/jeff/code/my-project/sub";
+        let name = std::path::Path::new(path)
+            .file_name()
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert_eq!(name, "sub");
+    }
 }
 
 fn cmd_rm(config: &mut Config, name: Option<String>) {

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -1,4 +1,3 @@
-use std::env;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -174,12 +173,6 @@ pub fn sorted_worktrees(
     }
 
     result
-}
-
-/// Determine the portal path from the current directory.
-pub fn detect_add_context() -> String {
-    let cwd = env::current_dir().expect("could not determine current directory");
-    collapse_tilde(&cwd)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Closes #8

`tp add` and `tp myproject` were structurally identical but one was a subcommand and the other a portal lookup. This required a `RESERVED_NAMES` list to prevent collisions, which was a workaround rather than a real solution.

This replaces all subcommands with mutually exclusive flags (`-a`, `-r`, `-l`, `-e`, `--completions`), making `tp <arg>` always a portal lookup with no exceptions. The `RESERVED_NAMES` list and `Commands` enum are deleted entirely. Along the way, `tp -a` now auto-names portals from the directory basename and `tp -r` can remove portals by matching the current directory. The `edit` subcommand and `-c` flag handling moved from the shell wrapper into warp-core as directives (`edit:`, `cd+c:`), reducing the shell wrapper to a pure directive dispatcher with no logic of its own.