### PR TITLE
Update README and CLAUDE.md for recent flag and shell changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,41 +4,24 @@ Directory teleportation tool with worktree-aware bookmarks called **portals**.
 
 ## Architecture
 
-Two components:
+Two components that split along a hard boundary: a subprocess cannot change the parent shell's working directory.
 
-- **`warp-core`** (Rust binary): handles config parsing, path resolution, worktree discovery, fzf integration. Outputs directives to stdout: `cd:<path>` (shell should cd) or plain text (shell should print). Never calls `cd` itself.
-- **`tp`** (zsh function in `shell/tp.zsh`): calls `warp-core`, interprets directives (`cd:`, `cd+c:`, `edit:`), executes shell-level actions. Pure dispatcher with no logic of its own.
+- **`warp-core`** (Rust binary): all logic lives here. Config, path resolution, worktree discovery, fzf pickers. Outputs directives to stdout (`cd:`, `cd+c:`, `edit:`, or plain text) but never performs shell actions itself.
+- **`tp`** (zsh function, embedded in the binary via `--init`): pure dispatcher. Calls `warp-core`, pattern-matches on the directive prefix, executes the shell-level action. No branching logic of its own.
 
 ## Key concepts
 
-- **Portal**: a named bookmark to any directory. Stored as `name = "~/path"` under `[portals]` in config. If the path is inside a git repo with multiple worktrees, tp automatically shows a picker to choose which worktree to resolve through.
-- **Substring matching**: `tp <query>` first tries an exact portal name match. If none, it searches portal names and paths for a case-insensitive substring match. A single match teleports directly; multiple matches open an fzf picker filtered to just those portals.
-- **Worktree awareness**: at teleport time, tp detects if a portal's path is inside a git repo. If the repo has multiple worktrees, a top-down fzf picker appears with colored `(current)` and `(main)` labels. The current worktree is pre-selected at the top. Use `-m` to skip the picker and go straight to the main worktree.
-- **Config**: TOML at `~/.config/tp/portals.toml`. Uses `dirs::home_dir().join(".config")` (XDG style), not `dirs::config_dir()` (which returns `~/Library/Application Support` on macOS).
+- **Portal**: a named bookmark to any directory. Stored as `name = "~/path"` under `[portals]` in config.
+- **Substring matching**: `tp <query>` tries exact name match first, then case-insensitive substring across names and paths. Single match teleports directly; multiple matches open an fzf picker.
+- **Worktree awareness**: if a portal's path is inside a git repo with multiple worktrees, tp shows a picker to choose which worktree to resolve through. `-m` skips the picker and goes to the main worktree; `-d` skips it and goes to the stored path directly.
+- **Config path**: `~/.config/tp/portals.toml`. Uses `dirs::home_dir().join(".config")` (XDG style), not `dirs::config_dir()` (which returns `~/Library/Application Support` on macOS).
 
-## Source layout
+## Key gotchas
 
-| File | Responsibility |
-|---|---|
-| `src/main.rs` | CLI definition (clap), flag dispatch, substring matching |
-| `src/config.rs` | TOML types (Config), load/save, add/remove |
-| `src/resolve.rs` | Tilde expansion, git worktree list, portal worktree context, detect_add_context |
-| `src/fzf.rs` | Format table rows, spawn fzf subprocess (ANSI-aware, index-based matching), parse selection |
-| `shell/tp.zsh` | Shell directive dispatcher + zsh tab completion |
-
-## Commands
-
-- `tp <query>` teleport to portal by exact name or substring match (with worktree picker if multiple worktrees)
-- `tp` (no args) fzf picker
-- `tp -a [name]` add portal for cwd (auto-names from directory basename if name omitted)
-- `tp -r [name]` remove portal (by name, or by cwd match if name omitted)
-- `tp -l` list all portals
-- `tp -e` open config in $EDITOR
-- `tp -m <query>` teleport to main worktree (skip picker)
-- `tp -d <query>` teleport directly to stored path (skip worktree picker entirely)
-- `tp -c <query>` teleport then open Claude (composes with -m)
-- `tp -p` find broken portals (dry-run)
-- `tp -p -f` remove broken portals
+- **Shell integration is embedded**: `shell/tp.zsh` is compiled into the binary via `include_str!` and served by `warp-core --init zsh`. There is no separate install step for the shell wrapper. Users add `eval "$(warp-core --init zsh)"` to their `.zshrc`.
+- **Directive protocol**: warp-core communicates with the shell function through a line-oriented protocol. Adding a new directive means updating both the Rust `emit_*` call and the `case` statement in `tp.zsh`.
+- **fzf is required at runtime**: tp will error with an install hint if fzf is not found. No fallback picker exists.
+- **No `clap_complete`**: shell completions are hand-rolled in `tp.zsh` (calls `warp-core -l` and extracts names). The `clap_complete` crate is not a dependency.
 
 ## Development
 
@@ -47,7 +30,6 @@ source "$HOME/.cargo/env"
 cargo build                    # build
 cargo run -- <args>            # test warp-core without installing (avoids worktree binary collisions)
 cargo install --path .         # install to ~/.cargo/bin/
-cp shell/tp.zsh ~/shell/common/tp.zsh  # update shell wrapper
 ```
 
 ## Git workflow

--- a/README.md
+++ b/README.md
@@ -30,11 +30,14 @@ tp blog         # teleport to a portal by exact name
 tp dot          # substring match: jumps directly if one match, picker if multiple
 tp              # fzf picker over all portals
 tp -m blog      # skip worktree picker, go straight to main worktree
+tp -d blog      # skip worktree picker, go to the stored path directly (experimental)
 tp -c blog      # teleport then open Claude Code
-tp add myplace  # create a portal from current directory
-tp rm myplace   # remove a portal
-tp ls           # list all portals
-tp edit         # open config in $EDITOR
+tp -a myplace   # create a portal from current directory (auto-names from basename if omitted)
+tp -r myplace   # remove a portal (removes by cwd match if name omitted)
+tp -l           # list all portals
+tp -e           # open config in $EDITOR
+tp -p           # find broken portals (dry-run)
+tp -p -f        # remove broken portals
 ```
 
 ## Worktree support
@@ -56,4 +59,4 @@ notes = "~/Documents/notes"
 
 ## How it works
 
-`tp` is a zsh function that calls `warp-core` (the Rust binary). The binary handles config, path resolution, worktree discovery, and fzf integration, then outputs a `cd:/path` directive. The shell function interprets it and runs `cd`. This split exists because a subprocess cannot change the parent shell's working directory.
+`tp` is a zsh function that calls `warp-core` (the Rust binary). The binary handles config, path resolution, worktree discovery, and fzf integration, then outputs directives to stdout: `cd:/path` (change directory), `cd+c:/path` (change directory and open Claude), or `edit:/path` (open file in `$EDITOR`). The shell function interprets these and executes the corresponding shell-level action. This split exists because a subprocess cannot change the parent shell's working directory.

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,7 +51,7 @@ struct Cli {
     #[arg(short = 'm', long = "main", conflicts_with_all = ["add", "remove", "list", "edit", "prune", "direct"])]
     main_worktree: bool,
 
-    /// Skip worktree picker, go to the stored path directly
+    /// Skip worktree picker, go to the stored path directly (experimental)
     #[arg(short = 'd', long = "direct", conflicts_with_all = ["add", "remove", "list", "edit", "prune", "main_worktree"])]
     direct: bool,
 


### PR DESCRIPTION
## Summary

- README: replace stale subcommand examples (`tp add`, `tp rm`, `tp ls`, `tp edit`) with current flag syntax (`-a`, `-r`, `-l`, `-e`), add missing `-d` and `-p` flags, document all three output directives (`cd:`, `cd+c:`, `edit:`) in the "How it works" section
- CLAUDE.md: rewrite to focus on architecture concepts and gotchas instead of per-file source layout table and commands list that go stale on every refactor
- Mark `-d`/`--direct` as experimental in both CLI help text and README

## Test plan

- [ ] `cargo build` compiles cleanly
- [ ] `warp-core --help` shows `(experimental)` on the `-d` flag
- [ ] README usage examples match actual CLI flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)