### PR TITLE
Simplify codebase: remove redundant functions, reduce subprocess spawning

### DIFF
--- a/src/fzf.rs
+++ b/src/fzf.rs
@@ -74,24 +74,6 @@ pub fn format_worktree_entries(worktrees: &[crate::resolve::WorktreeInfo]) -> Ve
         .collect()
 }
 
-/// Strip ANSI escape codes from a string for comparison.
-fn strip_ansi(s: &str) -> String {
-    let mut result = String::with_capacity(s.len());
-    let mut in_escape = false;
-    for c in s.chars() {
-        if in_escape {
-            if c.is_ascii_alphabetic() {
-                in_escape = false;
-            }
-        } else if c == '\x1b' {
-            in_escape = true;
-        } else {
-            result.push(c);
-        }
-    }
-    result
-}
-
 /// Format broken portal entries for prune output. Returns display lines with aligned columns.
 pub fn format_prune_entries(portals: &[(String, String)]) -> Vec<String> {
     let name_width = portals.iter().map(|(n, _)| n.len()).max().unwrap_or(0);
@@ -104,7 +86,15 @@ pub fn format_prune_entries(portals: &[(String, String)]) -> Vec<String> {
 /// Spawn fzf with the given lines and prompt. Returns the index of the selected line or None.
 pub fn pick(lines: &[String], prompt: &str) -> Option<usize> {
     let fzf = Command::new("fzf")
-        .args(["--height=~50%", "--layout=reverse", "--ansi", "--border", &format!("--prompt={} ", prompt)])
+        .args([
+            "--height=~50%",
+            "--layout=reverse",
+            "--ansi",
+            "--border",
+            "--delimiter=\t",
+            "--with-nth=2..",
+            &format!("--prompt={} ", prompt),
+        ])
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::inherit())
@@ -120,8 +110,8 @@ pub fn pick(lines: &[String], prompt: &str) -> Option<usize> {
     };
 
     if let Some(mut stdin) = child.stdin.take() {
-        for line in lines {
-            let _ = writeln!(stdin, "{}", line);
+        for (i, line) in lines.iter().enumerate() {
+            let _ = writeln!(stdin, "{}\t{}", i, line);
         }
     }
 
@@ -130,13 +120,8 @@ pub fn pick(lines: &[String], prompt: &str) -> Option<usize> {
         return None;
     }
 
-    let selected = String::from_utf8(output.stdout).ok()?.trim_end().to_string();
-    if selected.is_empty() {
-        return None;
-    }
-
-    let stripped = strip_ansi(&selected);
-    lines.iter().position(|l| strip_ansi(l) == stripped)
+    let selected = String::from_utf8(output.stdout).ok()?;
+    selected.trim_end().split('\t').next()?.parse().ok()
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,49 +86,48 @@ fn emit_cd_or_exit(name: &str, target: std::path::PathBuf, claude: bool) {
 
 fn teleport_to_portal(name: &str, path: &str, mode: WorktreeMode, claude: bool) {
     if matches!(mode, WorktreeMode::Direct) {
-        emit_cd_or_exit(name, resolve::resolve_portal(path), claude);
+        emit_cd_or_exit(name, resolve::expand_tilde(path), claude);
         return;
     }
 
-    match portal_worktree_context(path) {
-        Some(ctx) if ctx.worktrees.len() > 1 => {
-            let worktree_root = if matches!(mode, WorktreeMode::MainOnly) {
-                ctx.main_worktree
-            } else {
-                let sorted = sorted_worktrees(
-                    &ctx.worktrees,
-                    &ctx.main_worktree,
-                    ctx.current_worktree.as_deref(),
-                );
-                let entries = fzf::format_worktree_entries(&sorted);
-                let display_lines: Vec<String> =
-                    entries.iter().map(|(d, _)| d.clone()).collect();
+    let Some(ctx) = portal_worktree_context(path) else {
+        emit_cd_or_exit(name, resolve::expand_tilde(path), claude);
+        return;
+    };
 
-                match fzf::pick(&display_lines, "Select worktree:") {
-                    Some(idx) => entries[idx].1.clone(),
-                    None => process::exit(130),
-                }
-            };
+    let worktree_root = if ctx.worktrees.len() > 1 && matches!(mode, WorktreeMode::Picker) {
+        let sorted = sorted_worktrees(
+            &ctx.worktrees,
+            &ctx.main_worktree,
+            ctx.current_worktree.as_deref(),
+        );
+        let entries = fzf::format_worktree_entries(&sorted);
+        let display_lines: Vec<String> = entries.iter().map(|(d, _)| d.clone()).collect();
+        match fzf::pick(&display_lines, "Select worktree:") {
+            Some(idx) => entries[idx].1.clone(),
+            None => process::exit(130),
+        }
+    } else {
+        ctx.main_worktree
+    };
 
-            let target = if ctx.relative_path.is_empty() {
-                worktree_root
-            } else {
-                worktree_root.join(&ctx.relative_path)
-            };
-            emit_cd_or_exit(name, target, claude);
+    emit_cd_or_exit(name, worktree_root.join(&ctx.relative_path), claude);
+}
+
+fn pick_and_teleport(
+    portals: &std::collections::BTreeMap<String, String>,
+    mode: WorktreeMode,
+    claude: bool,
+) {
+    let entries = fzf::format_portal_entries(portals, "* ");
+    let display_lines: Vec<String> = entries.iter().map(|(d, _)| d.clone()).collect();
+    match fzf::pick(&display_lines, "Teleport:") {
+        Some(idx) => {
+            let name = &entries[idx].1;
+            let path = portals.get(name).unwrap();
+            teleport_to_portal(name, path, mode, claude);
         }
-        Some(ctx) if ctx.worktrees.len() == 1 => {
-            let wt = ctx.worktrees.into_iter().next().unwrap();
-            let target = if ctx.relative_path.is_empty() {
-                wt
-            } else {
-                wt.join(&ctx.relative_path)
-            };
-            emit_cd_or_exit(name, target, claude);
-        }
-        _ => {
-            emit_cd_or_exit(name, resolve::resolve_portal(path), claude);
-        }
+        None => process::exit(130),
     }
 }
 
@@ -167,39 +166,17 @@ fn cmd_teleport(config: &Config, query: &str, mode: WorktreeMode, claude: bool) 
                 .iter()
                 .map(|(n, p)| ((*n).clone(), (*p).clone()))
                 .collect();
-            let entries = fzf::format_portal_entries(&filtered, "* ");
-            let display_lines: Vec<String> = entries.iter().map(|(d, _)| d.clone()).collect();
-
-            match fzf::pick(&display_lines, "Teleport:") {
-                Some(idx) => {
-                    let name = &entries[idx].1;
-                    let path = config.portals.get(name).unwrap();
-                    teleport_to_portal(name, path, mode, claude);
-                }
-                None => process::exit(130),
-            }
+            pick_and_teleport(&filtered, mode, claude);
         }
     }
 }
 
 fn cmd_pick(config: &Config) {
-    let entries = fzf::format_portal_entries(&config.portals, "* ");
-
-    if entries.is_empty() {
+    if config.portals.is_empty() {
         eprintln!("No portals configured. Use 'tp -a <name>' to create one.");
         process::exit(1);
     }
-
-    let display_lines: Vec<String> = entries.iter().map(|(d, _)| d.clone()).collect();
-
-    match fzf::pick(&display_lines, "Teleport:") {
-        Some(idx) => {
-            let name = &entries[idx].1;
-            let path = config.portals.get(name).unwrap();
-            teleport_to_portal(name, path, WorktreeMode::Picker, false);
-        }
-        None => process::exit(130),
-    }
+    pick_and_teleport(&config.portals, WorktreeMode::Picker, false);
 }
 
 fn cmd_add(config: &mut Config, name: Option<String>) {

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -37,34 +37,6 @@ pub fn git_toplevel_for(dir: &Path) -> Option<PathBuf> {
     Some(PathBuf::from(path))
 }
 
-/// Get the path relative to the repo root for a specific directory.
-/// Uses `git rev-parse --show-prefix` which handles worktree indirection correctly.
-pub fn git_show_prefix(dir: &Path) -> Option<String> {
-    let output = Command::new("git")
-        .args(["-C", &dir.display().to_string(), "rev-parse", "--show-prefix"])
-        .output()
-        .ok()?;
-    if !output.status.success() {
-        return None;
-    }
-    let prefix = String::from_utf8(output.stdout).ok()?.trim().to_string();
-    // git returns trailing slash for subdirs, strip it
-    Some(prefix.trim_end_matches('/').to_string())
-}
-
-/// Get the git toplevel for the current directory, if any.
-pub fn git_toplevel() -> Option<PathBuf> {
-    let output = Command::new("git")
-        .args(["rev-parse", "--show-toplevel"])
-        .output()
-        .ok()?;
-    if !output.status.success() {
-        return None;
-    }
-    let path = String::from_utf8(output.stdout).ok()?.trim().to_string();
-    Some(PathBuf::from(path))
-}
-
 /// Get all worktrees for a repo.
 pub fn git_worktree_list(repo_path: &Path) -> Vec<PathBuf> {
     let output = Command::new("git")
@@ -84,11 +56,6 @@ pub fn git_worktree_list(repo_path: &Path) -> Vec<PathBuf> {
         .collect()
 }
 
-/// Resolve a portal to an absolute path.
-pub fn resolve_portal(path: &str) -> PathBuf {
-    expand_tilde(path)
-}
-
 /// Context for resolving a portal that lives inside a git repo.
 pub struct PortalContext {
     pub worktrees: Vec<PathBuf>,
@@ -101,21 +68,37 @@ pub struct PortalContext {
 /// Returns None if the path is not inside a git repo.
 pub fn portal_worktree_context(portal_path: &str) -> Option<PortalContext> {
     let expanded = expand_tilde(portal_path);
-
-    // Find the repo root for this path
     let toplevel = git_toplevel_for(&expanded)?;
 
-    // Relative path within the repo (empty string if at repo root).
-    // Uses git show-prefix to handle worktree indirection correctly.
-    let relative_path = git_show_prefix(&expanded).unwrap_or_default();
+    let relative_path = match (expanded.canonicalize(), toplevel.canonicalize()) {
+        (Ok(ce), Ok(ct)) => ce
+            .strip_prefix(&ct)
+            .map(|p| p.to_string_lossy().into_owned())
+            .unwrap_or_default(),
+        _ => String::new(),
+    };
 
-    // Get worktree list from this repo (works from any worktree)
-    let worktrees = git_worktree_list(&toplevel);
+    // Only spawn `git worktree list` if the repo actually uses worktrees.
+    let git_path = toplevel.join(".git");
+    let may_have_worktrees = if git_path.is_dir() {
+        git_path
+            .join("worktrees")
+            .read_dir()
+            .is_ok_and(|mut d| d.next().is_some())
+    } else {
+        true
+    };
+
+    let worktrees = if may_have_worktrees {
+        git_worktree_list(&toplevel)
+    } else {
+        vec![toplevel.clone()]
+    };
+
     let main_wt = worktrees.first().cloned().unwrap_or_else(|| toplevel.clone());
 
-    // Detect current worktree using already-fetched list (avoids a second git subprocess)
-    let current = git_toplevel().and_then(|cwd_toplevel| {
-        worktrees.iter().find(|wt| **wt == cwd_toplevel).cloned()
+    let current = std::env::current_dir().ok().and_then(|cwd| {
+        worktrees.iter().find(|wt| cwd.starts_with(wt)).cloned()
     });
 
     Some(PortalContext {


### PR DESCRIPTION
## Summary

- Remove 4 redundant functions: `resolve_portal` (alias for `expand_tilde`), `git_toplevel` (duplicate of `git_toplevel_for`), `git_show_prefix` (replaced by `canonicalize` + `strip_prefix`), and `strip_ansi` (replaced by fzf `--with-nth` index tracking)
- Collapse `teleport_to_portal` from 3 match arms to a flat `let-else` structure, removing duplicated join-relative-path logic and the unnecessary `is_empty()` guard (since `join("")` is a no-op)
- Extract `pick_and_teleport` helper to deduplicate the fzf-pick-then-teleport pattern in `cmd_teleport` and `cmd_pick`
- Short-circuit `git worktree list` for single-worktree repos by checking `.git/worktrees/` first, and detect current worktree via `cwd.starts_with()` instead of a subprocess

Net result: 55 fewer lines, and single-worktree teleports drop from 4 git subprocesses to 1.

## Test plan

- [x] `cargo test` passes (19/19)
- [x] `cargo clippy` clean
- [ ] CI passes
- [ ] Manual smoke test: `tp <portal>` with single-worktree and multi-worktree repos


🤖 Generated with [Claude Code](https://claude.com/claude-code)