### PR TITLE
fix: preserve symlink paths when adding portals

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -180,7 +180,7 @@ fn cmd_pick(config: &Config) {
 }
 
 fn cmd_add(config: &mut Config, name: Option<String>) {
-    let cwd = std::env::current_dir().expect("could not determine current directory");
+    let cwd = resolve::logical_cwd();
 
     let name = match name {
         Some(n) => n,
@@ -214,7 +214,13 @@ fn cmd_rm(config: &mut Config, name: Option<String>) {
             let matches: Vec<_> = config
                 .portals
                 .iter()
-                .filter(|(_, path)| resolve::expand_tilde(path) == cwd)
+                .filter(|(_, path)| {
+                    resolve::expand_tilde(path)
+                        .canonicalize()
+                        .ok()
+                        .as_ref()
+                        == Some(&cwd)
+                })
                 .map(|(name, _)| name.clone())
                 .collect();
 

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -24,6 +24,29 @@ pub fn collapse_tilde(path: &Path) -> String {
     path.display().to_string()
 }
 
+/// Resolve the logical working directory from an optional PWD value and a
+/// physical fallback. Prefers PWD when it is an absolute path pointing to an
+/// existing directory, so symlink paths are preserved.
+fn resolve_logical_cwd(pwd: Option<&str>, fallback: PathBuf) -> PathBuf {
+    if let Some(pwd) = pwd {
+        let p = PathBuf::from(pwd);
+        if p.is_absolute() && p.is_dir() {
+            return p;
+        }
+    }
+    fallback
+}
+
+/// Get the current working directory, preferring the PWD environment variable
+/// to preserve symlink paths. Falls back to `std::env::current_dir()` if PWD
+/// is unset or invalid.
+pub fn logical_cwd() -> PathBuf {
+    resolve_logical_cwd(
+        std::env::var("PWD").ok().as_deref(),
+        std::env::current_dir().expect("could not determine current directory"),
+    )
+}
+
 /// Get the git toplevel for a specific directory.
 pub fn git_toplevel_for(dir: &Path) -> Option<PathBuf> {
     let output = Command::new("git")
@@ -196,6 +219,37 @@ mod tests {
         assert!(sorted[0].is_current);
         assert!(sorted[0].is_main);
         assert_eq!(sorted[1].path, wt_a);
+    }
+
+    #[test]
+    fn logical_cwd_prefers_valid_pwd() {
+        let fallback = PathBuf::from("/fallback");
+        let result = resolve_logical_cwd(Some("/tmp"), fallback);
+        assert_eq!(result, PathBuf::from("/tmp"));
+    }
+
+    #[test]
+    fn logical_cwd_rejects_relative_pwd() {
+        let fallback = PathBuf::from("/fallback");
+        let result = resolve_logical_cwd(Some("relative/path"), fallback.clone());
+        assert_eq!(result, fallback);
+    }
+
+    #[test]
+    fn logical_cwd_rejects_nonexistent_pwd() {
+        let fallback = PathBuf::from("/fallback");
+        let result = resolve_logical_cwd(
+            Some("/surely/this/does/not/exist/anywhere"),
+            fallback.clone(),
+        );
+        assert_eq!(result, fallback);
+    }
+
+    #[test]
+    fn logical_cwd_falls_back_when_unset() {
+        let fallback = PathBuf::from("/fallback");
+        let result = resolve_logical_cwd(None, fallback.clone());
+        assert_eq!(result, fallback);
     }
 
     #[test]


### PR DESCRIPTION
Closes #18

## Summary

- `cmd_add` now reads the `PWD` environment variable (which shells maintain as the logical working directory with symlinks intact) instead of calling `std::env::current_dir()` (which resolves symlinks via `getcwd`). Falls back to `current_dir()` when PWD is unset or invalid.
- `cmd_rm` path comparison now canonicalizes both sides so removal works regardless of whether the user navigated through a symlink or the canonical path.
- Adds 4 tests for the new `resolve_logical_cwd` function covering valid PWD, relative PWD, nonexistent PWD, and unset PWD.

## Known limitation

Worktree picker paths come from `git worktree list` (canonical). When teleporting through the worktree picker, the landing path will be canonical, not symlink-preserved. Acceptable since the picker emphasizes worktree names, and reverse-mapping canonical paths through symlinks would add significant complexity for little benefit.

## Test plan

- [x] `cargo test` passes (23 tests, including 4 new)
- [x] `cargo clippy` clean
- [x] Manual test: `cd ~/r/k-repo` (symlinked), `tp -a test-symlink`, verified `portals.toml` stores `~/r/k-repo` not `~/Klaviyo/Repos/k-repo`
- [x] Manual test: `tp test-symlink` from another directory lands in symlink path
- [x] Manual test: `tp -r test-symlink` removes the portal successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)