### PR TITLE
rename binary from warp-core to tp-core

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,8 +6,8 @@ Directory teleportation tool with worktree-aware bookmarks called **portals**.
 
 Two components that split along a hard boundary: a subprocess cannot change the parent shell's working directory.
 
-- **`warp-core`** (Rust binary): all logic lives here. Config, path resolution, worktree discovery, fzf pickers. Outputs directives to stdout (`cd:`, `cd+c:`, `edit:`, or plain text) but never performs shell actions itself.
-- **`tp`** (zsh function, embedded in the binary via `--init`): pure dispatcher. Calls `warp-core`, pattern-matches on the directive prefix, executes the shell-level action. No branching logic of its own.
+- **`tp-core`** (Rust binary): all logic lives here. Config, path resolution, worktree discovery, fzf pickers. Outputs directives to stdout (`cd:`, `cd+c:`, `edit:`, or plain text) but never performs shell actions itself.
+- **`tp`** (zsh function, embedded in the binary via `--init`): pure dispatcher. Calls `tp-core`, pattern-matches on the directive prefix, executes the shell-level action. No branching logic of its own.
 
 ## Key concepts
 
@@ -18,16 +18,16 @@ Two components that split along a hard boundary: a subprocess cannot change the 
 
 ## Key gotchas
 
-- **Shell integration is embedded**: `shell/tp.zsh` is compiled into the binary via `include_str!` and served by `warp-core --init zsh`. There is no separate install step for the shell wrapper. Users add `eval "$(warp-core --init zsh)"` to their `.zshrc`.
-- **Directive protocol**: warp-core communicates with the shell function through a line-oriented protocol. Adding a new directive means updating both the Rust `emit_*` call and the `case` statement in `tp.zsh`.
+- **Shell integration is embedded**: `shell/tp.zsh` is compiled into the binary via `include_str!` and served by `tp-core --init zsh`. There is no separate install step for the shell wrapper. Users add `eval "$(tp-core --init zsh)"` to their `.zshrc`.
+- **Directive protocol**: tp-core communicates with the shell function through a line-oriented protocol. Adding a new directive means updating both the Rust `emit_*` call and the `case` statement in `tp.zsh`.
 - **fzf is required at runtime**: tp will error with an install hint if fzf is not found. No fallback picker exists.
-- **No `clap_complete`**: shell completions are hand-rolled in `tp.zsh` (calls `warp-core -l` and extracts names). The `clap_complete` crate is not a dependency.
+- **No `clap_complete`**: shell completions are hand-rolled in `tp.zsh` (calls `tp-core -l` and extracts names). The `clap_complete` crate is not a dependency.
 
 ## Development
 
 ```bash
 source "$HOME/.cargo/env"
 cargo build                    # build
-cargo run -- <args>            # test warp-core without installing (avoids worktree binary collisions)
+cargo run -- <args>            # test tp-core without installing (avoids worktree binary collisions)
 cargo install --path .         # install to ~/.cargo/bin/
 ```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -505,6 +505,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
+name = "tp-core"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "dirs",
+ "serde",
+ "tempfile",
+ "toml",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -521,17 +532,6 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
-name = "warp-core"
-version = "0.1.0"
-dependencies = [
- "clap",
- "dirs",
- "serde",
- "tempfile",
- "toml",
-]
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "warp-core"
+name = "tp-core"
 version = "0.1.0"
 edition = "2021"
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ cargo install --path .
 Add to your `~/.zshrc`:
 
 ```zsh
-eval "$(warp-core --init zsh)"
+eval "$(tp-core --init zsh)"
 ```
 
 ## Usage
@@ -59,4 +59,4 @@ notes = "~/Documents/notes"
 
 ## How it works
 
-`tp` is a zsh function that calls `warp-core` (the Rust binary). The binary handles config, path resolution, worktree discovery, and fzf integration, then outputs directives to stdout: `cd:/path` (change directory), `cd+c:/path` (change directory and open Claude), or `edit:/path` (open file in `$EDITOR`). The shell function interprets these and executes the corresponding shell-level action. This split exists because a subprocess cannot change the parent shell's working directory.
+`tp` is a zsh function that calls `tp-core` (the Rust binary). The binary handles config, path resolution, worktree discovery, and fzf integration, then outputs directives to stdout: `cd:/path` (change directory), `cd+c:/path` (change directory and open Claude), or `edit:/path` (open file in `$EDITOR`). The shell function interprets these and executes the corresponding shell-level action. This split exists because a subprocess cannot change the parent shell's working directory.

--- a/shell/tp.zsh
+++ b/shell/tp.zsh
@@ -1,5 +1,5 @@
 tp() {
-  local result=$(warp-core "$@")
+  local result=$(tp-core "$@")
   local rc=$?
 
   case "$result" in
@@ -15,7 +15,7 @@ tp() {
 _tp() {
   local -a names
   if [[ -f ~/.config/tp/portals.toml ]]; then
-    names=($(warp-core -l 2>/dev/null | awk '{print $1}'))
+    names=($(tp-core -l 2>/dev/null | awk '{print $1}'))
   fi
   _describe 'portal' names
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ enum WorktreeMode {
 }
 
 #[derive(Parser)]
-#[command(name = "warp-core", version, about = "Engine for tp (teleport)")]
+#[command(name = "tp-core", version, about = "Engine for tp (teleport)")]
 struct Cli {
     /// Add a portal for the current directory
     #[arg(short = 'a', long = "add", conflicts_with_all = ["remove", "list", "edit", "prune"])]


### PR DESCRIPTION
## Summary

- Renames the Rust binary from `warp-core` to `tp-core` across all source files and docs
- `tp-core` pairs naturally with the `tp` shell function, making the two-component architecture immediately obvious
- Pure mechanical rename — no behavior, flag, or protocol changes

## Migration

Existing users need to:
1. Re-run `cargo install --path .`
2. Update `.zshrc`: `eval "$(tp-core --init zsh)"`

## Test Plan

- [x] `cargo build` succeeds, binary at `target/debug/tp-core`
- [x] `tp-core --version` outputs `tp-core 0.1.0`
- [x] All 23 tests pass
- [x] `tp-core --init zsh` outputs shell function with no `warp-core` references
- [x] `grep -r "warp-core" .` returns zero hits in source files

🤖 Generated with [Claude Code](https://claude.com/claude-code)