### PR TITLE
docs: recommend rustup for Rust install

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,12 @@ A directory teleportation tool for the terminal. Create portals in your favorite
 
 ## Install
 
-Requires Rust and fzf.
+Requires [rustup](https://rustup.rs) and fzf.
 
 ```bash
+# Install Rust via rustup (if you haven't already)
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+
 brew install fzf
 cargo install --path .
 ```


### PR DESCRIPTION
## Summary

- Adds explicit `rustup` install step to the README
- Replaces the implicit assumption that users have `~/.cargo/bin` in PATH

## Why

Installing Rust via Homebrew (`brew install rust`) doesn't add `~/.cargo/bin` to PATH, so `tp-core` ends up installed but not found when sourcing shell config. `rustup` handles this automatically via `~/.cargo/env`.

## Test Plan

- [x] Fresh install following README steps produces a working `tp`/`tp-core`

🤖 Generated with [Claude Code](https://claude.com/claude-code)