### PR TITLE
Upgrade release workflows to fix deprecated warnings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,41 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    name: Build ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: macos-latest
+            target: aarch64-apple-darwin
+          - os: macos-13
+            target: x86_64-apple-darwin
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Build
+        run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Stage binary
+        run: cp target/${{ matrix.target }}/release/tp-core tp-core-${{ matrix.target }}
+
+      - name: Upload to release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: tp-core-${{ matrix.target }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
             target: aarch64-apple-darwin
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -37,6 +37,6 @@ jobs:
         run: cp target/${{ matrix.target }}/release/tp-core tp-core-${{ matrix.target }}
 
       - name: Upload to release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: tp-core-${{ matrix.target }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+permissions:
+  contents: write
+
 jobs:
   build:
     name: Build ${{ matrix.target }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,8 +20,6 @@ jobs:
         include:
           - os: macos-latest
             target: aarch64-apple-darwin
-          - os: macos-13
-            target: x86_64-apple-darwin
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Fixes:

>   Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may
  not work as expected: actions/checkout@v4, softprops/action-gh-release@v2. Actions will be
  forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be
  removed from the runner on September 16th, 2026. Please check if updated versions of these
  actions are available that support Node.js 24. To opt into Node.js 24 now, set the
  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your
  workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting
  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see:
  https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/