### PR TITLE
docs: overhaul README and improve first-run UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,11 @@ $ tp auth
 
 ## Install
 
-Requires [rustup](https://rustup.rs) and [fzf](https://github.com/junegunn/fzf).
+Requires [fzf](https://github.com/junegunn/fzf).
 
 ```bash
-cargo install --git https://github.com/jeffdt/teleport
+brew install jeffdt/tap/tp
+brew install fzf  # if you don't have it already
 ```
 
 Add to your `~/.zshrc`:
@@ -44,6 +45,8 @@ Add to your `~/.zshrc`:
 ```zsh
 eval "$(tp-core --init zsh)"
 ```
+
+> Apple Silicon only for now. If you have Rust installed, `cargo install --git https://github.com/jeffdt/teleport` works on any platform.
 
 ## How it works
 

--- a/README.md
+++ b/README.md
@@ -2,22 +2,41 @@
 
 [![CI](https://github.com/jeffdt/teleport/actions/workflows/ci.yml/badge.svg)](https://github.com/jeffdt/teleport/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
-[![Built with Rust](https://img.shields.io/badge/built%20with-Rust-orange.svg)](https://www.rust-lang.org)
 
-A directory teleportation tool for the terminal. Create portals in your favorite directories and jump to them instantly, with built-in git worktree support.
+Directory teleportation with worktree-aware bookmarks.
 
-> **Heads up:** tp is under active development. Commands, config format, and behavior may change without notice, and there are no guarantees of backwards compatibility between versions. Once the core workflow settles, stability will be prioritized.
+## Demo
+
+Drop a portal anywhere, jump there instantly from anywhere else:
+
+```bash
+$ cd ~/code/user-authentication-service
+$ tp -a auth
+Added portal 'auth'
+
+$ cd ~
+$ tp auth
+~/code/user-authentication-service $
+```
+
+<!-- gif: add portal and teleport -->
+
+For git repos with multiple worktrees, `tp` shows a picker so you can choose which worktree to land in:
+
+```bash
+$ tp auth
+  auth  ~/code/user-authentication-service        (main)
+> auth  ~/code/user-authentication-service-feat   (current)
+```
+
+<!-- gif: worktree picker in action -->
 
 ## Install
 
-Requires [rustup](https://rustup.rs) and fzf.
+Requires [rustup](https://rustup.rs) and [fzf](https://github.com/junegunn/fzf).
 
 ```bash
-# Install Rust via rustup (if you haven't already)
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-
-brew install fzf
-cargo install --path .
+cargo install --git https://github.com/jeffdt/teleport
 ```
 
 Add to your `~/.zshrc`:
@@ -26,40 +45,39 @@ Add to your `~/.zshrc`:
 eval "$(tp-core --init zsh)"
 ```
 
+## How it works
+
+**Portals** are named bookmarks stored in `~/.config/tp/portals.toml`. Add one from any directory with `tp -a <name>`, then `tp <name>` jumps there from anywhere in your shell. Type just `tp` to open a fuzzy picker over all portals, or a partial name to narrow it down -- exact match wins outright, otherwise a picker opens.
+
+If a portal's target is inside a git repo with multiple worktrees, tp shows a picker so you can choose which worktree to resolve through. The current worktree is pre-selected at the top. Use `-m` to skip straight to the main worktree, or `-d` to go to the stored path directly.
+
 ## Usage
 
 ```bash
-tp blog         # teleport to a portal by exact name
-tp dot          # substring match: jumps directly if one match, picker if multiple
-tp              # fzf picker over all portals
-tp -m blog      # skip worktree picker, go straight to main worktree
-tp -d blog      # skip worktree picker, go to the stored path directly (experimental)
-tp -c blog      # teleport then open Claude Code
-tp -a myplace   # create a portal from current directory (auto-names from basename if omitted)
-tp -r myplace   # remove a portal (removes by cwd match if name omitted)
-tp -l           # list all portals
-tp -e           # open config in $EDITOR
-tp -p           # find broken portals (dry-run)
-tp -p -f        # remove broken portals
+tp                  # fzf picker over all portals
+tp auth             # teleport by name (exact or substring match)
+tp -a auth          # add a portal for the current directory
+tp -a               # add a portal, auto-named from the directory basename
+tp -r auth          # remove a portal by name
+tp -r               # remove the portal pointing to the current directory
+tp -m auth          # skip worktree picker, go to main worktree
+tp -d auth          # skip worktree picker, go to stored path directly
+tp -c auth          # teleport then open Claude Code
+tp -l               # list all portals
+tp -e               # open config in $EDITOR
+tp -p               # find broken portals (dry-run)
+tp -p -f            # remove broken portals
 ```
-
-## Worktree support
-
-If a portal points inside a git repo that has multiple worktrees, tp shows an fzf picker so you can choose which worktree to resolve through. The current worktree is pre-selected at the top, with colored `(current)` and `(main)` labels. If the repo has only one worktree, tp goes there directly.
-
-Use `-m` to skip the picker and always land in the main worktree.
 
 ## Config
 
-Stored at `~/.config/tp/portals.toml`:
+Portals are stored at `~/.config/tp/portals.toml`:
 
 ```toml
 [portals]
+auth    = "~/code/user-authentication-service"
 dotfiles = "~/dotfiles"
-blog = "~/projects/blog"
-notes = "~/Documents/notes"
+notes   = "~/Documents/notes"
 ```
 
-## How it works
-
-`tp` is a zsh function that calls `tp-core` (the Rust binary). The binary handles config, path resolution, worktree discovery, and fzf integration, then outputs directives to stdout: `cd:/path` (change directory), `cd+c:/path` (change directory and open Claude), or `edit:/path` (open file in `$EDITOR`). The shell function interprets these and executes the corresponding shell-level action. This split exists because a subprocess cannot change the parent shell's working directory.
+You can edit this directly (`tp -e`) or manage portals through `tp -a` and `tp -r`.

--- a/README.md
+++ b/README.md
@@ -3,30 +3,21 @@
 [![CI](https://github.com/jeffdt/teleport/actions/workflows/ci.yml/badge.svg)](https://github.com/jeffdt/teleport/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
-Directory teleportation with worktree-aware bookmarks.
+Directory portals that cut through worktree sprawl.
 
 ## Demo
 
-Drop a portal anywhere, jump there instantly from anywhere else:
-
 ```bash
-$ cd ~/code/user-authentication-service
+$ cd ~/code/authentication-service
 $ tp -a auth
 Added portal 'auth'
 
-$ cd ~
 $ tp auth
-~/code/user-authentication-service $
-```
-
-<!-- gif: add portal and teleport -->
-
-For git repos with multiple worktrees, `tp` shows a picker so you can choose which worktree to land in:
-
-```bash
-$ tp auth
-  auth  ~/code/user-authentication-service        (main)
-> auth  ~/code/user-authentication-service-feat   (current)
+Select worktree:
+  3/3
+| ~/code/authentication-service.feature-oauth   (current)
+  ~/code/authentication-service                 (main)
+  ~/code/authentication-service.pr-review
 ```
 
 <!-- gif: worktree picker in action -->
@@ -50,9 +41,9 @@ eval "$(tp-core --init zsh)"
 
 ## How it works
 
-**Portals** are named bookmarks stored in `~/.config/tp/portals.toml`. Add one from any directory with `tp -a <name>`, then `tp <name>` jumps there from anywhere in your shell. Type just `tp` to open a fuzzy picker over all portals, or a partial name to narrow it down -- exact match wins outright, otherwise a picker opens.
+**Portals** are named shortcuts to directories. `tp -a <name>` drops one wherever you are; `tp <name>` takes you there from anywhere. Type just `tp` to open a fuzzy picker, or a partial name to narrow it down.
 
-If a portal's target is inside a git repo with multiple worktrees, tp shows a picker so you can choose which worktree to resolve through. The current worktree is pre-selected at the top. Use `-m` to skip straight to the main worktree, or `-d` to go to the stored path directly.
+The real power is worktree awareness. If a portal points inside a git repo with multiple worktrees -- common when running parallel agents or juggling feature branches -- tp shows a picker so you land in the right one. One portal per repo, not one per worktree.
 
 ## Usage
 
@@ -78,7 +69,7 @@ Portals are stored at `~/.config/tp/portals.toml`:
 
 ```toml
 [portals]
-auth    = "~/code/user-authentication-service"
+auth     = "~/code/authentication-service"
 dotfiles = "~/dotfiles"
 notes   = "~/Documents/notes"
 ```

--- a/src/main.rs
+++ b/src/main.rs
@@ -173,7 +173,9 @@ fn cmd_teleport(config: &Config, query: &str, mode: WorktreeMode, claude: bool) 
 
 fn cmd_pick(config: &Config) {
     if config.portals.is_empty() {
-        eprintln!("No portals configured. Use 'tp -a <name>' to create one.");
+        eprintln!(
+            "No portals yet.\n\nA portal is a named shortcut to a directory -- worktree-aware for git repos\nwith multiple worktrees.\n\nAdd your first:\n  cd ~/code/user-authentication-service\n  tp -a auth        # 'tp auth' gets you here from anywhere\n\nRun 'tp --help' for all options."
+        );
         process::exit(1);
     }
     pick_and_teleport(&config.portals, WorktreeMode::Picker, false);


### PR DESCRIPTION
Pre-launch polish pass.

1. README is restructured demo-first: a shell transcript showing portal creation and the worktree picker now leads the page, with install and reference pushed below. Drops the "under active development" warning and the architecture internals section.

2. The empty-portals message (`tp` with no portals) is replaced with a hint that explains what a portal is, mentions worktree awareness, and shows a realistic example where the portal name is clearly better than the directory name. First contact with the tool now does more work.

3. jeffdt/homebrew-tap repo created with formula to install directly.