### PR TITLE
docs: split README demo into two focused examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,22 @@ Directory portals that cut through worktree sprawl.
 
 ## Demo
 
+Add a portal for the current directory:
+
 ```bash
-$ cd ~/code/authentication-service
+> ~/code/authentication-service
 $ tp -a auth
 Added portal 'auth'
+```
 
+Then jump to it from anywhere -- if the repo has multiple worktrees, tp picks one:
+
+```bash
+> ~/Downloads
 $ tp auth
 Select worktree:
   3/3
-| ~/code/authentication-service.feature-oauth   (current)
+| ~/code/authentication-service.feature-oauth
   ~/code/authentication-service                 (main)
   ~/code/authentication-service.pr-review
 ```


### PR DESCRIPTION
The original demo was confusing — it cd'd into `authentication-service` then immediately showed the worktree picker marking `feature-oauth` as current, which contradicted the previous step.

Splits it into two demos: one that shows adding a portal, one that shows jumping to it from an unrelated directory. The second demo also drops the misleading `(current)` annotation since you're teleporting from outside the repo entirely.