### PR TITLE
Split EDITOR into words when dispatching edit

### DIFF
--- a/shell/tp.zsh
+++ b/shell/tp.zsh
@@ -5,7 +5,7 @@ tp() {
   case "$result" in
     cd+c:*) cd "${result#cd+c:}" && claude ;;
     cd:*)   cd "${result#cd:}" ;;
-    edit:*) ${EDITOR:-vim} "${result#edit:}" ;;
+    edit:*) ${=EDITOR:-vim} "${result#edit:}" ;;
     *)      [[ -n "$result" ]] && echo "$result" ;;
   esac
 


### PR DESCRIPTION
The `tp -e` dispatch was breaking when `$EDITOR` held more than one word (e.g. `subl --wait`, `code -w`). zsh parameter expansion does not split values by default, so `${EDITOR:-vim}` was passing the whole string as a single command name and the shell reported `command not found: subl --wait`. Adding the `=` flag (`${=EDITOR:-vim}`) opts into word splitting on that expansion, which is the standard zsh idiom for invoking a stored command line. Single-word `EDITOR` values and the `vim` fallback continue to work unchanged.