### PR TITLE
Add configurable worktree nav mode and -w flag (closes #37)

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,13 +72,18 @@ tp -p -f            # remove broken portals
 
 ## Config
 
-Portals are stored at `~/.config/tp/portals.toml`:
+Config lives at `~/.config/tp/config.toml`:
 
 ```toml
+[settings]
+default_nav_mode = "direct"  # "picker" (default) or "direct"
+
 [portals]
 auth     = "~/code/authentication-service"
 dotfiles = "~/dotfiles"
-notes   = "~/Documents/notes"
+notes    = "~/Documents/notes"
 ```
 
-You can edit this directly (`tp -e`) or manage portals through `tp -a` and `tp -r`.
+`default_nav_mode` controls what happens when you teleport to a portal inside a multi-worktree repo. `picker` shows an fzf menu to choose a worktree; `direct` goes straight to the stored path. Override per-invocation with `-w` (picker) or `-d` (direct).
+
+You can edit the config directly (`tp -e`) or manage portals through `tp -a` and `tp -r`.

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,8 +3,24 @@ use std::collections::BTreeMap;
 use std::fs;
 use std::path::PathBuf;
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum NavMode {
+    #[default]
+    Picker,
+    Direct,
+}
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct Settings {
+    #[serde(default)]
+    pub default_nav_mode: NavMode,
+}
+
 #[derive(Debug, Serialize, Deserialize, Default)]
 pub struct Config {
+    #[serde(default)]
+    pub settings: Settings,
     #[serde(default)]
     pub portals: BTreeMap<String, String>,
 }
@@ -24,7 +40,13 @@ impl Config {
             return Self::default();
         }
         let contents = fs::read_to_string(&path).expect("could not read config file");
-        toml::from_str(&contents).expect("could not parse config file")
+        match toml::from_str(&contents) {
+            Ok(config) => config,
+            Err(e) => {
+                eprintln!("Error in config: {}", e);
+                std::process::exit(1);
+            }
+        }
     }
 
     pub fn save(&self) {
@@ -57,6 +79,47 @@ impl Config {
 mod tests {
     use super::*;
     use std::fs;
+
+    #[test]
+    fn nav_mode_picker_deserializes() {
+        let s: Settings = toml::from_str("default_nav_mode = \"picker\"").unwrap();
+        assert_eq!(s.default_nav_mode, NavMode::Picker);
+    }
+
+    #[test]
+    fn nav_mode_direct_deserializes() {
+        let s: Settings = toml::from_str("default_nav_mode = \"direct\"").unwrap();
+        assert_eq!(s.default_nav_mode, NavMode::Direct);
+    }
+
+    #[test]
+    fn settings_defaults_to_picker_when_absent() {
+        let s: Settings = toml::from_str("").unwrap();
+        assert_eq!(s.default_nav_mode, NavMode::Picker);
+    }
+
+    #[test]
+    fn nav_mode_invalid_value_includes_bad_value_in_error() {
+        let result: Result<Settings, _> = toml::from_str("default_nav_mode = \"blorp\"");
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("blorp"), "error should mention bad value, got: {}", msg);
+    }
+
+    #[test]
+    fn config_with_settings_section_deserializes() {
+        let toml = "[settings]\ndefault_nav_mode = \"direct\"\n[portals]\nfoo = \"~/foo\"";
+        let config: Config = toml::from_str(toml).unwrap();
+        assert_eq!(config.settings.default_nav_mode, NavMode::Direct);
+        assert_eq!(config.portals.get("foo").unwrap(), "~/foo");
+    }
+
+    #[test]
+    fn config_without_settings_section_defaults_to_picker() {
+        let toml = "[portals]\nfoo = \"~/foo\"";
+        let config: Config = toml::from_str(toml).unwrap();
+        assert_eq!(config.settings.default_nav_mode, NavMode::Picker);
+    }
 
     #[test]
     fn broken_portals_finds_missing_dirs() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -31,11 +31,27 @@ impl Config {
             .expect("could not determine home directory")
             .join(".config")
             .join("tp")
-            .join("portals.toml")
+            .join("config.toml")
+    }
+
+    // TODO: remove once all users have migrated (added alongside rename portals.toml -> config.toml)
+    fn legacy_path() -> PathBuf {
+        Self::path().with_file_name("portals.toml")
     }
 
     pub fn load() -> Self {
         let path = Self::path();
+        if !path.exists() {
+            // TODO: remove once all users have migrated
+            let legacy = Self::legacy_path();
+            if legacy.exists() {
+                if let Err(e) = fs::rename(&legacy, &path) {
+                    eprintln!("tp: could not rename portals.toml to config.toml: {}", e);
+                } else {
+                    eprintln!("tp: renamed ~/.config/tp/portals.toml -> ~/.config/tp/config.toml");
+                }
+            }
+        }
         if !path.exists() {
             return Self::default();
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,15 +6,8 @@ use std::process;
 
 use clap::Parser;
 
-use config::Config;
+use config::{Config, NavMode};
 use resolve::{portal_worktree_context, sorted_worktrees};
-
-#[derive(Clone, Copy)]
-enum WorktreeMode {
-    Picker,
-    MainOnly,
-    Direct,
-}
 
 #[derive(Parser)]
 #[command(name = "tp-core", version, about = "Engine for tp (teleport)")]
@@ -47,12 +40,12 @@ struct Cli {
     #[arg(long)]
     init: Option<String>,
 
-    /// Skip worktree picker, go to main worktree
-    #[arg(short = 'm', long = "main", conflicts_with_all = ["add", "remove", "list", "edit", "prune", "direct"])]
-    main_worktree: bool,
+    /// Show worktree picker (overrides default_nav_mode)
+    #[arg(short = 'w', long = "worktree", conflicts_with_all = ["add", "remove", "list", "edit", "prune", "direct"])]
+    worktree: bool,
 
     /// Skip worktree picker, go to the stored path directly (experimental)
-    #[arg(short = 'd', long = "direct", conflicts_with_all = ["add", "remove", "list", "edit", "prune", "main_worktree"])]
+    #[arg(short = 'd', long = "direct", conflicts_with_all = ["add", "remove", "list", "edit", "prune", "worktree"])]
     direct: bool,
 
     /// Open Claude after teleporting
@@ -64,13 +57,13 @@ struct Cli {
 }
 
 impl Cli {
-    fn worktree_mode(&self) -> WorktreeMode {
-        if self.direct {
-            WorktreeMode::Direct
-        } else if self.main_worktree {
-            WorktreeMode::MainOnly
+    fn worktree_mode(&self, default: NavMode) -> NavMode {
+        if self.worktree {
+            NavMode::Picker
+        } else if self.direct {
+            NavMode::Direct
         } else {
-            WorktreeMode::Picker
+            default
         }
     }
 }
@@ -84,8 +77,8 @@ fn emit_cd_or_exit(name: &str, target: std::path::PathBuf, claude: bool) {
     println!("{}:{}", prefix, target.display());
 }
 
-fn teleport_to_portal(name: &str, path: &str, mode: WorktreeMode, claude: bool) {
-    if matches!(mode, WorktreeMode::Direct) {
+fn teleport_to_portal(name: &str, path: &str, mode: NavMode, claude: bool) {
+    if matches!(mode, NavMode::Direct) {
         emit_cd_or_exit(name, resolve::expand_tilde(path), claude);
         return;
     }
@@ -95,7 +88,7 @@ fn teleport_to_portal(name: &str, path: &str, mode: WorktreeMode, claude: bool) 
         return;
     };
 
-    let worktree_root = if ctx.worktrees.len() > 1 && matches!(mode, WorktreeMode::Picker) {
+    let worktree_root = if ctx.worktrees.len() > 1 && matches!(mode, NavMode::Picker) {
         let sorted = sorted_worktrees(
             &ctx.worktrees,
             &ctx.main_worktree,
@@ -116,7 +109,7 @@ fn teleport_to_portal(name: &str, path: &str, mode: WorktreeMode, claude: bool) 
 
 fn pick_and_teleport(
     portals: &std::collections::BTreeMap<String, String>,
-    mode: WorktreeMode,
+    mode: NavMode,
     claude: bool,
 ) {
     let entries = fzf::format_portal_entries(portals, "* ");
@@ -144,7 +137,7 @@ fn find_matching_portals<'a>(config: &'a Config, query: &str) -> Vec<(&'a String
         .collect()
 }
 
-fn cmd_teleport(config: &Config, query: &str, mode: WorktreeMode, claude: bool) {
+fn cmd_teleport(config: &Config, query: &str, mode: NavMode, claude: bool) {
     if let Some(path) = config.portals.get(query) {
         teleport_to_portal(query, path, mode, claude);
         return;
@@ -178,7 +171,7 @@ fn cmd_pick(config: &Config) {
         );
         process::exit(1);
     }
-    pick_and_teleport(&config.portals, WorktreeMode::Picker, false);
+    pick_and_teleport(&config.portals, config.settings.default_nav_mode, false);
 }
 
 fn cmd_add(config: &mut Config, name: Option<String>) {
@@ -327,7 +320,7 @@ fn main() {
     } else if cli.prune {
         cmd_prune(&mut config, cli.force);
     } else if let Some(ref name) = cli.name {
-        let mode = cli.worktree_mode();
+        let mode = cli.worktree_mode(config.settings.default_nav_mode);
         cmd_teleport(&config, name, mode, cli.claude);
     } else {
         cmd_pick(&config);
@@ -337,6 +330,36 @@ fn main() {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn worktree_mode_w_flag_forces_picker() {
+        let cli = Cli::try_parse_from(["tp-core", "-w", "myportal"]).unwrap();
+        assert_eq!(cli.worktree_mode(NavMode::Direct), NavMode::Picker);
+    }
+
+    #[test]
+    fn worktree_mode_d_flag_forces_direct() {
+        let cli = Cli::try_parse_from(["tp-core", "-d", "myportal"]).unwrap();
+        assert_eq!(cli.worktree_mode(NavMode::Picker), NavMode::Direct);
+    }
+
+    #[test]
+    fn worktree_mode_no_flag_uses_config_default_direct() {
+        let cli = Cli::try_parse_from(["tp-core", "myportal"]).unwrap();
+        assert_eq!(cli.worktree_mode(NavMode::Direct), NavMode::Direct);
+    }
+
+    #[test]
+    fn worktree_mode_no_flag_uses_config_default_picker() {
+        let cli = Cli::try_parse_from(["tp-core", "myportal"]).unwrap();
+        assert_eq!(cli.worktree_mode(NavMode::Picker), NavMode::Picker);
+    }
+
+    #[test]
+    fn m_flag_is_rejected() {
+        let result = Cli::try_parse_from(["tp-core", "-m", "myportal"]);
+        assert!(result.is_err(), "-m flag should not be accepted");
+    }
 
     #[test]
     fn init_zsh_outputs_shell_function() {


### PR DESCRIPTION
Adds a `default_nav_mode` setting and renames the config file from `portals.toml` to `config.toml`. Also adds a `-w` flag to force the worktree picker on demand, and removes the `-m`/`--main` flag in favour of the simpler two-mode model (just point your portal at main if that's where you want to land).

**To migrate your config file** (tp will also do this automatically on first run):
```zsh
mv ~/.config/tp/portals.toml ~/.config/tp/config.toml
```

**To set a nav mode default**, add to `~/.config/tp/config.toml`:
```toml
[settings]
default_nav_mode = "direct"  # or "picker" (default)
```

Bare `tp` and `tp <name>` both respect the setting; explicit flags (`-w`, `-d`) always override it.