### PR TITLE
Bump version to 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -506,7 +506,7 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tp-core"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "clap",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tp-core"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
Release bump for v0.2.0. Notable changes since v0.1.0:

- Configurable worktree nav mode and `-w` flag (#38)
- Fix `EDITOR` splitting when dispatching edit (#36)
- Binary release workflow + macOS aarch64 binaries (#32, #33)
- README overhaul and first-run UX improvements (#34, #35, #39, #40)

After merge, tag `v0.2.0` on the merge commit to trigger the release workflow.