### PR TITLE
Add tp . worktree picker and release automation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,3 +31,62 @@ cargo build                    # build
 cargo run -- <args>            # test tp-core without installing (avoids worktree binary collisions)
 cargo install --path .         # install to ~/.cargo/bin/
 ```
+
+## Packaging and distribution
+
+tp ships as a prebuilt binary through a personal Homebrew tap:
+
+- A `v*` git tag triggers `release.yml`, which builds the `aarch64-apple-darwin`
+  binary and attaches it to the GitHub Release as `tp-core-aarch64-apple-darwin`.
+- `jeffdt/homebrew-tap` carries `Formula/tp.rb`, a binary formula that
+  downloads that asset by pinned `sha256`. Install with
+  `brew install jeffdt/tap/tp`. The installed binary is named `tp-core`; the
+  `tp` shell function itself is not packaged (see "Shell integration is
+  embedded" above).
+
+### Cutting a release
+
+**Every push to `main` that changes shipped behavior must also cut a release.**
+Users install via Homebrew, which only ever sees tagged release binaries, never
+`main`. A commit on `main` with no accompanying release is invisible to anyone
+who runs `brew upgrade`: the code is "shipped" in git but not to users. So
+unless a change is purely internal (docs, tests, CI, scratch under `specs/` or
+`plans/`), finish the job by running the steps below in the same session: bump,
+tag, wait for CI, and update the tap. Don't leave `main` ahead of the latest
+release.
+
+Shipped changes reach `main` via PR, and the version bump rides in that PR.
+Once it has merged, cut the tag and update the tap. The tap is a separate
+repo, `jeffdt/homebrew-tap`; clone it if it isn't already checked out.
+`scripts/release.sh` expects it at `~/code/homebrew-tap`; set `TP_TAP_DIR` if
+it lives elsewhere.
+
+`scripts/release.sh` automates the mechanical steps:
+
+1. On the feature branch, before opening the PR: `scripts/release.sh bump
+   <patch|minor|major>`. Reads the current version from `Cargo.toml`, applies
+   the bump, refreshes `Cargo.lock` (`cargo build --release`), and commits.
+   That commit rides in the PR as usual. Picking `patch` vs `minor` vs `major`
+   is the one call the script doesn't make for you -- same judgment as always
+   (a bug fix is patch, new user-facing behavior like `tp .` is minor).
+2. After the PR merges: `git checkout main && git pull`, then
+   `scripts/release.sh cut`. It reads the version already on `main` (no bump
+   decision left -- that was step 1), tags and pushes `vX.Y.Z`, waits for
+   `release.yml` (which builds and attaches a single asset named
+   **`tp-core-aarch64-apple-darwin`** to the GitHub Release), downloads and
+   hashes that asset, updates and validates `jeffdt/homebrew-tap`'s
+   `Formula/tp.rb`, pushes the tap, and runs `brew update && brew upgrade
+   jeffdt/tap/tp` locally, ending on a confirmed `tp-core --version`. It
+   refuses to run off `main`, with a dirty tree, or against a tag that
+   already exists, rather than guessing.
+
+The formula carries `depends_on arch: :arm64` and `depends_on :macos` and a
+top-level `url` (the version is scanned from the URL, e.g.
+`.../download/vX.Y.Z/tp-core-...`; there is no separate `version` line) so the
+tap's `brew test-bot` CI passes -- keep that shape by hand if editing the
+formula outside the script. `release.sh cut` only ever rewrites the `url` and
+`sha256` lines.
+
+Currently Apple Silicon only. Supporting Intel means adding
+`x86_64-apple-darwin` to the release matrix, an Intel branch in the formula,
+and updating `scripts/release.sh`'s asset handling.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -506,7 +506,7 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tp-core"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "clap",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tp-core"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ The real power is worktree awareness. If a portal points inside a git repo with 
 ```bash
 tp                  # pick a portal from a list and jump there
 tp auth             # jump to the auth portal
+tp .                # open the worktree picker for the repo you're standing in
 tp -w auth          # jump to auth and choose a worktree
 tp -d auth          # jump to auth, skip the worktree picker
 tp -c auth          # jump to auth and open Claude Code

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# Release helper mirroring CLAUDE.md's "Cutting a release" workflow.
+#
+#   scripts/release.sh bump <patch|minor|major>
+#       Run on the feature branch, before merging its PR. Bumps Cargo.toml,
+#       refreshes Cargo.lock, commits. The bump then rides in the PR as
+#       CLAUDE.md requires.
+#
+#   scripts/release.sh cut
+#       Run after that PR has merged into main. Reads the version already
+#       committed there (no bump-type decision left to make), tags, waits
+#       for release.yml, hashes the asset, updates jeffdt/homebrew-tap,
+#       and upgrades the local install.
+#
+# Set TP_TAP_DIR if the tap isn't checked out at ~/code/homebrew-tap.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+CARGO_TOML="$REPO_ROOT/Cargo.toml"
+TAP_DIR="${TP_TAP_DIR:-$HOME/code/homebrew-tap}"
+ASSET="tp-core-aarch64-apple-darwin"
+
+current_version() {
+    grep -m1 '^version = ' "$CARGO_TOML" | sed -E 's/version = "(.*)"/\1/'
+}
+
+next_version() {
+    local kind="$1" ver major minor patch
+    ver="$(current_version)"
+    IFS='.' read -r major minor patch <<< "$ver"
+    case "$kind" in
+        major) major=$((major + 1)); minor=0; patch=0 ;;
+        minor) minor=$((minor + 1)); patch=0 ;;
+        patch) patch=$((patch + 1)) ;;
+        *) echo "error: bump kind must be patch, minor, or major" >&2; exit 1 ;;
+    esac
+    echo "$major.$minor.$patch"
+}
+
+cmd_bump() {
+    local kind="${1:?usage: release.sh bump <patch|minor|major>}"
+    local old new
+    old="$(current_version)"
+    new="$(next_version "$kind")"
+    echo "==> Bumping $old -> $new ($kind)"
+    sed -i '' -E "s/^version = \"$old\"/version = \"$new\"/" "$CARGO_TOML"
+    (cd "$REPO_ROOT" && cargo build --release)
+    git -C "$REPO_ROOT" add Cargo.toml Cargo.lock
+    git -C "$REPO_ROOT" commit -m "Bump version to $new"
+    echo "==> Committed. Include this commit in the feature PR; run 'release.sh cut' after it merges to main."
+}
+
+cmd_cut() {
+    cd "$REPO_ROOT"
+
+    local branch
+    branch="$(git branch --show-current)"
+    if [[ "$branch" != "main" ]]; then
+        echo "error: must be on main (currently on $branch)" >&2
+        exit 1
+    fi
+    if [[ -n "$(git status --porcelain)" ]]; then
+        echo "error: working tree not clean" >&2
+        exit 1
+    fi
+
+    echo "==> Pulling main"
+    git pull --ff-only
+
+    local version tag
+    version="$(current_version)"
+    tag="v$version"
+
+    if git rev-parse "$tag" >/dev/null 2>&1; then
+        echo "error: tag $tag already exists" >&2
+        exit 1
+    fi
+
+    echo "==> Tagging $tag on $(git rev-parse --short HEAD)"
+    git tag -a "$tag" -m "Release $version"
+    git push origin "$tag"
+
+    echo "==> Waiting for release.yml to start"
+    local run_id=""
+    for _ in $(seq 1 10); do
+        run_id="$(gh run list --workflow=release.yml --limit 5 --json databaseId,headBranch \
+            -q ".[] | select(.headBranch == \"$tag\") | .databaseId" | head -1)"
+        [[ -n "$run_id" ]] && break
+        sleep 3
+    done
+    if [[ -z "$run_id" ]]; then
+        echo "error: no release.yml run showed up for $tag after 30s" >&2
+        exit 1
+    fi
+    gh run watch "$run_id" --exit-status
+
+    echo "==> Downloading asset and hashing"
+    local tmpdir sha
+    tmpdir="$(mktemp -d)"
+    gh release download "$tag" -p "$ASSET" -D "$tmpdir"
+    sha="$(shasum -a 256 "$tmpdir/$ASSET" | awk '{print $1}')"
+    echo "    sha256: $sha"
+
+    if [[ ! -d "$TAP_DIR" ]]; then
+        echo "error: tap not found at $TAP_DIR (set TP_TAP_DIR)" >&2
+        exit 1
+    fi
+
+    echo "==> Updating $TAP_DIR/Formula/tp.rb"
+    (cd "$TAP_DIR" && git pull --ff-only)
+    local formula="$TAP_DIR/Formula/tp.rb"
+    sed -i '' -E "s#download/v[0-9]+\.[0-9]+\.[0-9]+/$ASSET#download/$tag/$ASSET#" "$formula"
+    sed -i '' -E "s/sha256 \"[a-f0-9]+\"/sha256 \"$sha\"/" "$formula"
+
+    echo "==> Validating formula"
+    (cd "$TAP_DIR" && brew style jeffdt/tap)
+    (cd "$TAP_DIR" && brew readall --aliases --os=all --arch=all jeffdt/tap)
+    (cd "$TAP_DIR" && brew audit --except=installed --tap=jeffdt/tap)
+
+    echo "==> Pushing tap"
+    (cd "$TAP_DIR" && git add Formula/tp.rb && git commit -m "Bump tp to $version" && git push)
+
+    echo "==> Upgrading local install"
+    brew update
+    brew upgrade jeffdt/tap/tp
+    tp-core --version
+
+    echo "==> Done. tp $version is live."
+}
+
+case "${1:-}" in
+    bump) shift; cmd_bump "$@" ;;
+    cut) cmd_cut ;;
+    *)
+        echo "usage: $0 {bump <patch|minor|major>|cut}" >&2
+        exit 1
+        ;;
+esac

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,7 +52,7 @@ struct Cli {
     #[arg(short = 'c', long = "claude", conflicts_with_all = ["add", "remove", "list", "edit", "prune"])]
     claude: bool,
 
-    /// Portal name or teleport query
+    /// Portal name, teleport query, or "." for the current repo's worktree picker
     name: Option<String>,
 }
 
@@ -65,6 +65,10 @@ impl Cli {
         } else {
             default
         }
+    }
+
+    fn is_current_dir(&self) -> bool {
+        self.name.as_deref() == Some(".")
     }
 }
 
@@ -321,7 +325,12 @@ fn main() {
         cmd_prune(&mut config, cli.force);
     } else if let Some(ref name) = cli.name {
         let mode = cli.worktree_mode(config.settings.default_nav_mode);
-        cmd_teleport(&config, name, mode, cli.claude);
+        if cli.is_current_dir() {
+            let cwd = resolve::logical_cwd();
+            teleport_to_portal(".", &cwd.display().to_string(), mode, cli.claude);
+        } else {
+            cmd_teleport(&config, name, mode, cli.claude);
+        }
     } else {
         cmd_pick(&config);
     }
@@ -359,6 +368,24 @@ mod tests {
     fn m_flag_is_rejected() {
         let result = Cli::try_parse_from(["tp-core", "-m", "myportal"]);
         assert!(result.is_err(), "-m flag should not be accepted");
+    }
+
+    #[test]
+    fn is_current_dir_true_for_dot() {
+        let cli = Cli::try_parse_from(["tp-core", "."]).unwrap();
+        assert!(cli.is_current_dir());
+    }
+
+    #[test]
+    fn is_current_dir_false_for_portal_name() {
+        let cli = Cli::try_parse_from(["tp-core", "myportal"]).unwrap();
+        assert!(!cli.is_current_dir());
+    }
+
+    #[test]
+    fn is_current_dir_false_when_no_name() {
+        let cli = Cli::try_parse_from(["tp-core"]).unwrap();
+        assert!(!cli.is_current_dir());
     }
 
     #[test]


### PR DESCRIPTION
Adds `tp .` so you can open the worktree picker for whatever repo the current directory is in, without needing to remember which portal points into it - it reuses the existing worktree-aware teleport machinery unchanged, just fed the cwd instead of a stored portal path.

Also ports `scripts/release.sh` from a sibling project (smux), which itself mirrored this repo's release pattern but is the one that actually got the bump/tag/homebrew-tap automation script. tp never had it, so cutting a release meant doing all those steps by hand. This PR includes the version bump to 0.3.0 that rides along per that workflow.