### PR TITLE
Add -u/--under flag to list or pick portals under cwd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -506,7 +506,7 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tp-core"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "clap",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tp-core"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ tp .                # open the worktree picker for the repo you're standing in
 tp -w auth          # jump to auth and choose a worktree
 tp -d auth          # jump to auth, skip the worktree picker
 tp -c auth          # jump to auth and open Claude Code
+tp -u               # pick a portal nested under the current directory
+tp -l -u            # list portals nested under the current directory
 ```
 
 **Manage portals**

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,11 +13,11 @@ use resolve::{portal_worktree_context, sorted_worktrees};
 #[command(name = "tp-core", version, about = "Engine for tp (teleport)")]
 struct Cli {
     /// Add a portal for the current directory
-    #[arg(short = 'a', long = "add", conflicts_with_all = ["remove", "list", "edit", "prune"])]
+    #[arg(short = 'a', long = "add", conflicts_with_all = ["remove", "list", "edit", "prune", "under"])]
     add: bool,
 
     /// Remove a portal
-    #[arg(short = 'r', long = "rm", conflicts_with_all = ["add", "list", "edit", "prune"])]
+    #[arg(short = 'r', long = "rm", conflicts_with_all = ["add", "list", "edit", "prune", "under"])]
     remove: bool,
 
     /// List all portals
@@ -25,16 +25,20 @@ struct Cli {
     list: bool,
 
     /// Open config in editor
-    #[arg(short = 'e', long = "edit", conflicts_with_all = ["add", "remove", "list", "prune"])]
+    #[arg(short = 'e', long = "edit", conflicts_with_all = ["add", "remove", "list", "prune", "under"])]
     edit: bool,
 
     /// Find and remove broken portals (dry-run by default, use with -f to remove)
-    #[arg(short = 'p', long = "prune", conflicts_with_all = ["add", "remove", "list", "edit"])]
+    #[arg(short = 'p', long = "prune", conflicts_with_all = ["add", "remove", "list", "edit", "under"])]
     prune: bool,
 
     /// Actually remove broken portals (use with -p)
     #[arg(short = 'f', long = "force", requires = "prune")]
     force: bool,
+
+    /// List/pick portals nested under the current directory
+    #[arg(short = 'u', long = "under", conflicts_with_all = ["add", "remove", "edit", "prune"])]
+    under: bool,
 
     /// Print shell integration code for the given shell
     #[arg(long)]
@@ -308,6 +312,33 @@ fn cmd_ls(config: &Config) {
     }
 }
 
+fn cmd_under(config: &Config, mode: NavMode, claude: bool) {
+    let cwd = resolve::logical_cwd();
+    let matches = find_portals_under(config, &cwd);
+
+    if matches.is_empty() {
+        println!("No portals found under {}", resolve::collapse_tilde(&cwd));
+        return;
+    }
+
+    pick_and_teleport(&matches, mode, claude);
+}
+
+fn cmd_ls_under(config: &Config) {
+    let cwd = resolve::logical_cwd();
+    let matches = find_portals_under(config, &cwd);
+
+    if matches.is_empty() {
+        println!("No portals found under {}", resolve::collapse_tilde(&cwd));
+        return;
+    }
+
+    let entries = fzf::format_portal_entries(&matches, "");
+    for (display, _) in &entries {
+        println!("{}", display);
+    }
+}
+
 fn main() {
     let cli = Cli::parse();
 
@@ -330,8 +361,13 @@ fn main() {
         cmd_add(&mut config, cli.name);
     } else if cli.remove {
         cmd_rm(&mut config, cli.name);
+    } else if cli.list && cli.under {
+        cmd_ls_under(&config);
     } else if cli.list {
         cmd_ls(&config);
+    } else if cli.under {
+        let mode = cli.worktree_mode(config.settings.default_nav_mode);
+        cmd_under(&config, mode, cli.claude);
     } else if cli.edit {
         cmd_edit();
     } else if cli.prune {
@@ -399,6 +435,49 @@ mod tests {
     fn is_current_dir_false_when_no_name() {
         let cli = Cli::try_parse_from(["tp-core"]).unwrap();
         assert!(!cli.is_current_dir());
+    }
+
+    #[test]
+    fn under_flag_short_parses() {
+        let cli = Cli::try_parse_from(["tp-core", "-u"]).unwrap();
+        assert!(cli.under);
+    }
+
+    #[test]
+    fn under_flag_long_parses() {
+        let cli = Cli::try_parse_from(["tp-core", "--under"]).unwrap();
+        assert!(cli.under);
+    }
+
+    #[test]
+    fn under_conflicts_with_add() {
+        let result = Cli::try_parse_from(["tp-core", "-u", "-a"]);
+        assert!(result.is_err(), "-u and -a should conflict");
+    }
+
+    #[test]
+    fn under_conflicts_with_remove() {
+        let result = Cli::try_parse_from(["tp-core", "-u", "-r"]);
+        assert!(result.is_err(), "-u and -r should conflict");
+    }
+
+    #[test]
+    fn under_conflicts_with_edit() {
+        let result = Cli::try_parse_from(["tp-core", "-u", "-e"]);
+        assert!(result.is_err(), "-u and -e should conflict");
+    }
+
+    #[test]
+    fn under_conflicts_with_prune() {
+        let result = Cli::try_parse_from(["tp-core", "-u", "-p"]);
+        assert!(result.is_err(), "-u and -p should conflict");
+    }
+
+    #[test]
+    fn under_and_list_parse_together() {
+        let cli = Cli::try_parse_from(["tp-core", "-l", "-u"]).unwrap();
+        assert!(cli.list);
+        assert!(cli.under);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -141,6 +141,19 @@ fn find_matching_portals<'a>(config: &'a Config, query: &str) -> Vec<(&'a String
         .collect()
 }
 
+/// Find portals whose path is a strict descendant of `dir` (not an exact match).
+fn find_portals_under(config: &Config, dir: &std::path::Path) -> std::collections::BTreeMap<String, String> {
+    config
+        .portals
+        .iter()
+        .filter(|(_, path)| {
+            let expanded = resolve::expand_tilde(path);
+            expanded != dir && expanded.starts_with(dir)
+        })
+        .map(|(name, path)| (name.clone(), path.clone()))
+        .collect()
+}
+
 fn cmd_teleport(config: &Config, query: &str, mode: NavMode, claude: bool) {
     if let Some(path) = config.portals.get(query) {
         teleport_to_portal(query, path, mode, claude);
@@ -463,5 +476,63 @@ mod tests {
             .collect();
 
         assert_eq!(matches.len(), 2);
+    }
+
+    #[test]
+    fn find_portals_under_matches_strict_subdir() {
+        let mut config = Config::default();
+        config.portals.insert("api".to_string(), "/home/jeff/code/monorepo/services/api".to_string());
+        config.portals.insert("notes".to_string(), "/home/jeff/Documents/notes".to_string());
+
+        let dir = std::path::Path::new("/home/jeff/code/monorepo");
+        let matches = find_portals_under(&config, dir);
+
+        assert_eq!(matches.len(), 1);
+        assert!(matches.contains_key("api"));
+    }
+
+    #[test]
+    fn find_portals_under_excludes_exact_cwd_match() {
+        let mut config = Config::default();
+        config.portals.insert("monorepo".to_string(), "/home/jeff/code/monorepo".to_string());
+
+        let dir = std::path::Path::new("/home/jeff/code/monorepo");
+        let matches = find_portals_under(&config, dir);
+
+        assert!(matches.is_empty());
+    }
+
+    #[test]
+    fn find_portals_under_excludes_sibling_with_shared_prefix() {
+        let mut config = Config::default();
+        config.portals.insert("foo2".to_string(), "/home/jeff/code/foo2".to_string());
+
+        let dir = std::path::Path::new("/home/jeff/code/foo");
+        let matches = find_portals_under(&config, dir);
+
+        assert!(matches.is_empty());
+    }
+
+    #[test]
+    fn find_portals_under_empty_when_no_match() {
+        let mut config = Config::default();
+        config.portals.insert("notes".to_string(), "/home/jeff/Documents/notes".to_string());
+
+        let dir = std::path::Path::new("/home/jeff/code/monorepo");
+        let matches = find_portals_under(&config, dir);
+
+        assert!(matches.is_empty());
+    }
+
+    #[test]
+    fn find_portals_under_resolves_tilde_paths() {
+        let mut config = Config::default();
+        config.portals.insert("api".to_string(), "~/code/monorepo/services/api".to_string());
+
+        let dir = resolve::expand_tilde("~/code/monorepo");
+        let matches = find_portals_under(&config, &dir);
+
+        assert_eq!(matches.len(), 1);
+        assert!(matches.contains_key("api"));
     }
 }


### PR DESCRIPTION
## Summary
- Adds `tp -u` / `--under`: fzf-picks a portal nested under the current directory (Enter teleports through the normal worktree-aware flow, Esc cancels).
- Adds `tp -l -u`: plain-prints the same filtered set without picking.
- Matching is strict-descendant only (`Path::starts_with`, component-wise) — a portal pointing at the exact cwd is excluded.

Closes #48.

## Test plan
- [x] `cargo test` — 49 passed (12 new: 5 for `find_portals_under`, 7 for CLI flag/conflicts)
- [x] Manual smoke test against a scratch `HOME`/config: `-l -u` filters correctly, `-u` and `-l -u` print the right "no portals found" message with zero matches (no fzf spawned), `-u -a` is rejected as a conflict, plain `-l` unchanged
- [x] Version bumped 0.3.0 -> 0.4.0 per this repo's release workflow (new user-facing flag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)