### PR TITLE
Check in Claude config and the tui-utils plugin source

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "enabledPlugins": {
+    "tui-utils@tui-utils": true
+  },
+  "extraKnownMarketplaces": {
+    "tui-utils": {
+      "source": {
+        "source": "github",
+        "repo": "jeffdt/tui-utils"
+      },
+      "autoUpdate": true
+    }
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,8 @@
 /specs
 /plans
 /.superpowers
-/.claude
+
+.claude/local
+.claude/worktrees
+.claude/settings.local.json
+.claude/scheduled_tasks.lock


### PR DESCRIPTION
Makes `.claude/` committable and checks in the plugin configuration, so the repo carries its own Claude Code setup instead of depending on whatever is in a given machine's user settings.

## Two changes

**`.gitignore`** stops blanket-ignoring `/.claude`. That rule predated auto mode and existed to keep `settings.local.json` permission churn out of commits. It now denies only the machine-local paths, matching boomerang:

```
.claude/local
.claude/worktrees
.claude/settings.local.json
.claude/scheduled_tasks.lock
```

**`.claude/settings.json`** already existed and already enabled the plugin, but was unreachable behind that ignore rule. It now also declares where the plugin comes from:

```json
{
  "enabledPlugins": { "tui-utils@tui-utils": true },
  "extraKnownMarketplaces": {
    "tui-utils": {
      "source": { "source": "github", "repo": "jeffdt/tui-utils" },
      "autoUpdate": true
    }
  }
}
```

`enabledPlugins` alone was not enough: the marketplace registration lived only in `~/.claude/settings.json`, so a fresh clone would enable a plugin it had no source for. `extraKnownMarketplaces` is the documented way to pin that at the repo level.

## Why now

The shared skills (`vhs-recording`, `cutting-a-release`, `mockup`, `live-preview`) moved from a vendored `.claude/skills/` subtree to the `tui-utils` plugin. That removed the last tracked thing under `.claude/`, which made the blanket ignore look harmless again, but it also moved the plugin wiring into user-level settings where the repo could not see it.

## Testing

`cargo test`: 49 passed, 0 failed. Verified `.claude/settings.json` is committable, `.claude/settings.local.json` is still ignored, and `/examples/mockup.rs` is still ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)