### PR TITLE
Normalize .gitignore across the TUI repos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,13 @@
 /target
 .envrc
-*.local.md
-/examples/mockup.rs
 
-/specs
 /plans
+/specs
 /.superpowers
+/examples/mockup.rs
+*.local.md
 
-.claude/local
-.claude/worktrees
-.claude/settings.local.json
-.claude/scheduled_tasks.lock
+/.claude/local
+/.claude/settings.local.json
+/.claude/scheduled_tasks.lock
+/.claude/worktrees


### PR DESCRIPTION
Aligns teleport's `.gitignore` with boomerang, rolomux, and backlog so all four share one shape: root-anchored `.claude` rules, consistent `/plans` and `/specs`, and `*.local.md`.

Part of a cross-repo reset that also removed the worktrunk `share-claude-config` hook. That hook symlinked `.claude/` from the primary worktree into each new worktree, which broke once `.claude/settings.json` became tracked: `ln -sf` drops the link *inside* an existing directory, producing a stray `.claude/.claude`. With the hook gone, the `.claude/.claude` ignore rules in the sibling repos are removed rather than carried forward, so a regression would surface instead of hiding.

No behavior change, config only. Nothing tracked is newly ignored and nothing ignored is newly exposed; `.claude/settings.json` stays committable and `settings.local.json`, `scheduled_tasks.lock`, and `worktrees/` stay ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)