### PR TITLE
Sort portals by directory with -s/--sort-dir

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -506,7 +506,7 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tp-core"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "clap",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tp-core"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 description = "Directory teleportation with worktree-aware bookmarks"
 license = "MIT"

--- a/src/fzf.rs
+++ b/src/fzf.rs
@@ -12,6 +12,7 @@ const MAX_DISPLAYED_NAMES: usize = 3;
 pub fn format_portal_entries(
     portals: &std::collections::BTreeMap<String, String>,
     prefix: &str,
+    sort_by_path: bool,
 ) -> Vec<(String, String)> {
     let mut by_path: std::collections::BTreeMap<&str, Vec<&str>> =
         std::collections::BTreeMap::new();
@@ -34,7 +35,11 @@ pub fn format_portal_entries(
             (display_names, path.to_string(), key)
         })
         .collect();
-    grouped.sort_by(|a, b| a.2.cmp(&b.2));
+    if sort_by_path {
+        grouped.sort_by(|a, b| a.1.cmp(&b.1));
+    } else {
+        grouped.sort_by(|a, b| a.2.cmp(&b.2));
+    }
 
     let name_width = grouped.iter().map(|(dn, _, _)| dn.len()).max().unwrap_or(0);
 
@@ -135,10 +140,40 @@ mod tests {
             .into_iter()
             .collect();
 
-        let entries = format_portal_entries(&portals, "* ");
+        let entries = format_portal_entries(&portals, "* ", false);
         assert_eq!(entries.len(), 1);
         assert!(entries[0].0.contains("*"));
         assert!(entries[0].0.contains("notes"));
+    }
+
+    #[test]
+    fn portal_entries_sorted_by_path_when_requested() {
+        let portals = [
+            ("zeta".to_string(), "~/aaa/zeta".to_string()),
+            ("alpha".to_string(), "~/zzz/alpha".to_string()),
+        ]
+        .into_iter()
+        .collect();
+
+        let entries = format_portal_entries(&portals, "", true);
+        assert_eq!(entries.len(), 2);
+        assert!(entries[0].0.contains("zeta"), "path ~/aaa/zeta should sort first");
+        assert!(entries[1].0.contains("alpha"), "path ~/zzz/alpha should sort second");
+    }
+
+    #[test]
+    fn portal_entries_sorted_by_name_by_default() {
+        let portals = [
+            ("zeta".to_string(), "~/aaa/zeta".to_string()),
+            ("alpha".to_string(), "~/zzz/alpha".to_string()),
+        ]
+        .into_iter()
+        .collect();
+
+        let entries = format_portal_entries(&portals, "", false);
+        assert_eq!(entries.len(), 2);
+        assert!(entries[0].0.contains("alpha"), "name alpha should sort first");
+        assert!(entries[1].0.contains("zeta"), "name zeta should sort second");
     }
 
     #[test]
@@ -188,7 +223,7 @@ mod tests {
         .into_iter()
         .collect();
 
-        let entries = format_portal_entries(&portals, "* ");
+        let entries = format_portal_entries(&portals, "* ", false);
         assert_eq!(entries.len(), 2);
 
         let grouped = entries.iter().find(|(d, _)| d.contains("insights")).unwrap();
@@ -213,7 +248,7 @@ mod tests {
         .into_iter()
         .collect();
 
-        let entries = format_portal_entries(&portals, "* ");
+        let entries = format_portal_entries(&portals, "* ", false);
         assert_eq!(entries.len(), 1);
         let display = &entries[0].0;
         assert!(display.contains("a, b, c"));

--- a/src/main.rs
+++ b/src/main.rs
@@ -120,7 +120,7 @@ fn pick_and_teleport(
     mode: NavMode,
     claude: bool,
 ) {
-    let entries = fzf::format_portal_entries(portals, "* ");
+    let entries = fzf::format_portal_entries(portals, "* ", false);
     let display_lines: Vec<String> = entries.iter().map(|(d, _)| d.clone()).collect();
     match fzf::pick(&display_lines, "Teleport:") {
         Some(idx) => {
@@ -306,7 +306,7 @@ fn cmd_ls(config: &Config) {
         return;
     }
 
-    let entries = fzf::format_portal_entries(&config.portals, "");
+    let entries = fzf::format_portal_entries(&config.portals, "", false);
     for (display, _) in &entries {
         println!("{}", display);
     }
@@ -333,7 +333,7 @@ fn cmd_ls_under(config: &Config) {
         return;
     }
 
-    let entries = fzf::format_portal_entries(&matches, "");
+    let entries = fzf::format_portal_entries(&matches, "", false);
     for (display, _) in &entries {
         println!("{}", display);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,6 +40,10 @@ struct Cli {
     #[arg(short = 'u', long = "under", conflicts_with_all = ["add", "remove", "edit", "prune"])]
     under: bool,
 
+    /// Sort listed portals by directory path instead of portal name
+    #[arg(short = 's', long = "sort-dir", requires = "list")]
+    sort_dir: bool,
+
     /// Print shell integration code for the given shell
     #[arg(long)]
     init: Option<String>,
@@ -300,13 +304,13 @@ fn cmd_prune(config: &mut Config, force: bool) {
     }
 }
 
-fn cmd_ls(config: &Config) {
+fn cmd_ls(config: &Config, sort_by_path: bool) {
     if config.portals.is_empty() {
         println!("No portals configured. Use 'tp -a <name>' to create one.");
         return;
     }
 
-    let entries = fzf::format_portal_entries(&config.portals, "", false);
+    let entries = fzf::format_portal_entries(&config.portals, "", sort_by_path);
     for (display, _) in &entries {
         println!("{}", display);
     }
@@ -324,7 +328,7 @@ fn cmd_under(config: &Config, mode: NavMode, claude: bool) {
     pick_and_teleport(&matches, mode, claude);
 }
 
-fn cmd_ls_under(config: &Config) {
+fn cmd_ls_under(config: &Config, sort_by_path: bool) {
     let cwd = resolve::logical_cwd();
     let matches = find_portals_under(config, &cwd);
 
@@ -333,7 +337,7 @@ fn cmd_ls_under(config: &Config) {
         return;
     }
 
-    let entries = fzf::format_portal_entries(&matches, "", false);
+    let entries = fzf::format_portal_entries(&matches, "", sort_by_path);
     for (display, _) in &entries {
         println!("{}", display);
     }
@@ -362,9 +366,9 @@ fn main() {
     } else if cli.remove {
         cmd_rm(&mut config, cli.name);
     } else if cli.list && cli.under {
-        cmd_ls_under(&config);
+        cmd_ls_under(&config, cli.sort_dir);
     } else if cli.list {
-        cmd_ls(&config);
+        cmd_ls(&config, cli.sort_dir);
     } else if cli.under {
         let mode = cli.worktree_mode(config.settings.default_nav_mode);
         cmd_under(&config, mode, cli.claude);
@@ -478,6 +482,27 @@ mod tests {
         let cli = Cli::try_parse_from(["tp-core", "-l", "-u"]).unwrap();
         assert!(cli.list);
         assert!(cli.under);
+    }
+
+    #[test]
+    fn sort_dir_requires_list() {
+        let result = Cli::try_parse_from(["tp-core", "-s"]);
+        assert!(result.is_err(), "-s without -l should be rejected");
+    }
+
+    #[test]
+    fn sort_dir_with_list_parses() {
+        let cli = Cli::try_parse_from(["tp-core", "-l", "-s"]).unwrap();
+        assert!(cli.list);
+        assert!(cli.sort_dir);
+    }
+
+    #[test]
+    fn sort_dir_with_list_and_under_parses() {
+        let cli = Cli::try_parse_from(["tp-core", "-l", "-u", "-s"]).unwrap();
+        assert!(cli.list);
+        assert!(cli.under);
+        assert!(cli.sort_dir);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add `-s`/`--sort-dir` to sort `tp -l` output by portal path instead of portal name, making duplicate/redundant portals (parent repo vs. subdir, symlink twins) easy to spot by clustering nearby paths together
- Composes with `-u`: `tp -l -u -s` sorts the under-cwd listing the same way
- `-s` requires `-l` and errors on its own, matching the existing `-f`/`-p` precedent

Closes #47.

## Test plan
- [x] `cargo test` — 54/54 passing, including new coverage for path-based sorting and CLI flag parsing/requires behavior
- [x] Manual smoke test: `tp-core -l -s` against a config with a parent portal and its subdir portal confirmed they sort adjacent to each other; `tp-core -s` alone confirmed to error