### PR TITLE
Worktree-aware -u, and tp -l <dir> for exact-location lookups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -506,7 +506,7 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tp-core"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "clap",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tp-core"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 description = "Directory teleportation with worktree-aware bookmarks"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ tp -u               # pick a portal nested under the current directory
 tp -a [name]        # add a portal for the current directory (auto-named if omitted)
 tp -r [name]        # remove a portal (defaults to the one for the current directory)
 tp -l               # list all portals
-tp -l -u            # list portals nested under the current directory
+tp -l -u            # list portals nested under the current directory (worktree-aware)
+tp -l .             # list portals pointing at exactly the current directory (worktree-aware)
 tp -e               # open config in $EDITOR
 ```
 

--- a/docs/demo/seed-demo.sh
+++ b/docs/demo/seed-demo.sh
@@ -82,11 +82,11 @@ EOF
 # has two corpses to find. Two rather than one so the swept output reads as
 # plural.
 #
-# They sit under ~/archive rather than ~/code on purpose. `-u` is a pure path
-# prefix match with no existence check (src/main.rs), so broken portals under
-# ~/code would pass the filter and `tp -l -u` would return five rows instead
-# of the three under-cwd.tape is built around. ~/archive itself is never
-# created either; only the paths' prefix matters here.
+# They sit under ~/archive rather than ~/code on purpose. `-u` has no
+# existence check (src/main.rs), so broken portals under ~/code would pass
+# the filter and `tp -l -u` would return five rows instead of the three
+# under-cwd.tape is built around. ~/archive itself is never created either;
+# only the location match matters here.
 
 # The tapes run `zsh -f` (no rc files, so a themed prompt cannot fight
 # `Set Theme`), which means the prompt must be set explicitly. It is written

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ struct Cli {
     #[arg(short = 'r', long = "rm", conflicts_with_all = ["add", "list", "edit", "prune", "under"])]
     remove: bool,
 
-    /// List all portals
+    /// List all portals, or with a directory argument (e.g. "."), only those located there
     #[arg(short = 'l', long = "ls", conflicts_with_all = ["add", "remove", "edit", "prune"])]
     list: bool,
 
@@ -413,6 +413,20 @@ fn cmd_ls_under(config: &Config, sort_by_path: bool) {
     }
 }
 
+fn cmd_ls_at(config: &Config, dir: &Path, sort_by_path: bool) {
+    let matches = find_portals_at(config, dir);
+
+    if matches.is_empty() {
+        println!("No portals found at {}", resolve::collapse_tilde(dir));
+        return;
+    }
+
+    let entries = fzf::format_portal_entries(&matches, "", sort_by_path);
+    for (display, _) in &entries {
+        println!("{}", display);
+    }
+}
+
 fn main() {
     let cli = Cli::parse();
 
@@ -437,6 +451,10 @@ fn main() {
         cmd_rm(&mut config, cli.name);
     } else if cli.list && cli.under {
         cmd_ls_under(&config, cli.sort_dir);
+    } else if cli.list && cli.name.is_some() {
+        let cwd = resolve::logical_cwd();
+        let dir = resolve_location_arg(&cwd, cli.name.as_deref().unwrap());
+        cmd_ls_at(&config, &dir, cli.sort_dir);
     } else if cli.list {
         cmd_ls(&config, cli.sort_dir);
     } else if cli.under {
@@ -573,6 +591,20 @@ mod tests {
         assert!(cli.list);
         assert!(cli.under);
         assert!(cli.sort_dir);
+    }
+
+    #[test]
+    fn list_with_dot_argument_parses() {
+        let cli = Cli::try_parse_from(["tp-core", "-l", "."]).unwrap();
+        assert!(cli.list);
+        assert_eq!(cli.name.as_deref(), Some("."));
+    }
+
+    #[test]
+    fn list_with_path_argument_parses() {
+        let cli = Cli::try_parse_from(["tp-core", "-l", "~/code/foo"]).unwrap();
+        assert!(cli.list);
+        assert_eq!(cli.name.as_deref(), Some("~/code/foo"));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod config;
 mod fzf;
 mod resolve;
 
+use std::path::{Path, PathBuf};
 use std::process;
 
 use clap::Parser;
@@ -36,7 +37,7 @@ struct Cli {
     #[arg(short = 'f', long = "force", requires = "prune")]
     force: bool,
 
-    /// List/pick portals nested under the current directory
+    /// List/pick portals nested under the current directory (worktree-aware)
     #[arg(short = 'u', long = "under", conflicts_with_all = ["add", "remove", "edit", "prune"])]
     under: bool,
 
@@ -149,17 +150,47 @@ fn find_matching_portals<'a>(config: &'a Config, query: &str) -> Vec<(&'a String
         .collect()
 }
 
-/// Find portals whose path is a strict descendant of `dir` (not an exact match).
-fn find_portals_under(config: &Config, dir: &std::path::Path) -> std::collections::BTreeMap<String, String> {
-    config
-        .portals
-        .iter()
-        .filter(|(_, path)| {
-            let expanded = resolve::expand_tilde(path);
-            expanded != dir && expanded.starts_with(dir)
-        })
-        .map(|(name, path)| (name.clone(), path.clone()))
-        .collect()
+/// Resolve `dir`'s location within its repo, worktree-aware: the repo's
+/// full worktree list, and `dir`'s path relative to whichever worktree
+/// contains it. `None` if `dir` isn't inside a git repo.
+fn worktree_location(dir: &Path) -> Option<(Vec<PathBuf>, PathBuf)> {
+    let worktrees = resolve::repo_worktrees_for(dir)?;
+    let canon = dir.canonicalize().unwrap_or_else(|_| dir.to_path_buf());
+    let (_, rel) = resolve::relative_to_worktree(&canon, &worktrees)?;
+    Some((worktrees, rel))
+}
+
+/// `path`'s location relative to `worktrees`, if it belongs to one of them.
+/// Canonicalizes first, since git reports physical (symlink-resolved) paths.
+fn relative_location(path: &Path, worktrees: &[PathBuf]) -> Option<PathBuf> {
+    let canon = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+    resolve::relative_to_worktree(&canon, worktrees).map(|(_, rel)| rel)
+}
+
+/// Find portals whose path is a strict descendant of `dir` (not an exact
+/// match), worktree-aware: a portal in a different worktree of the same
+/// repo as `dir` still counts as being under it.
+fn find_portals_under(config: &Config, dir: &Path) -> std::collections::BTreeMap<String, String> {
+    match worktree_location(dir) {
+        Some((worktrees, cwd_rel)) => config
+            .portals
+            .iter()
+            .filter(|(_, path)| {
+                relative_location(&resolve::expand_tilde(path), &worktrees)
+                    .is_some_and(|rel| rel != cwd_rel && rel.starts_with(&cwd_rel))
+            })
+            .map(|(name, path)| (name.clone(), path.clone()))
+            .collect(),
+        None => config
+            .portals
+            .iter()
+            .filter(|(_, path)| {
+                let expanded = resolve::expand_tilde(path);
+                expanded != dir && expanded.starts_with(dir)
+            })
+            .map(|(name, path)| (name.clone(), path.clone()))
+            .collect(),
+    }
 }
 
 fn cmd_teleport(config: &Config, query: &str, mode: NavMode, claude: bool) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -739,4 +739,59 @@ mod tests {
         assert_eq!(matches.len(), 1);
         assert!(matches.contains_key("api"));
     }
+
+    fn git_test(repo: &std::path::Path, args: &[&str]) {
+        let status = std::process::Command::new("git")
+            .args(["-c", "user.name=tp test"])
+            .args(["-c", "user.email=test@example.com"])
+            .args(["-c", "commit.gpgsign=false"])
+            .args(["-c", "init.defaultBranch=main"])
+            .args(["-C", repo.to_str().unwrap()])
+            .args(args)
+            .status()
+            .expect("git must be installed to run this test");
+        assert!(status.success(), "git {:?} failed", args);
+    }
+
+    #[test]
+    fn find_portals_under_and_at_cross_worktree_boundary() {
+        let scratch = tempfile::tempdir().unwrap();
+        let repo = scratch.path().join("repo");
+        std::fs::create_dir(&repo).unwrap();
+
+        git_test(&repo, &["init", "-q"]);
+        std::fs::write(repo.join("README.md"), "hello\n").unwrap();
+        git_test(&repo, &["add", "-A"]);
+        git_test(&repo, &["commit", "-q", "-m", "initial"]);
+
+        let feature_worktree = scratch.path().join("repo.feature");
+        git_test(
+            &repo,
+            &["worktree", "add", "-q", "-b", "feature", feature_worktree.to_str().unwrap()],
+        );
+
+        // The portal points at a subdirectory created after the initial commit, so it
+        // only exists in the main worktree's checkout -- create the equivalent
+        // directory in the feature worktree too, since that's what a real repo with
+        // this file on its branch would look like.
+        let services_dir = repo.join("services").join("api");
+        std::fs::create_dir_all(&services_dir).unwrap();
+        let feature_services_dir = feature_worktree.join("services").join("api");
+        std::fs::create_dir_all(&feature_services_dir).unwrap();
+
+        let mut config = Config::default();
+        config.portals.insert("api".to_string(), services_dir.display().to_string());
+
+        let under = find_portals_under(&config, &feature_worktree);
+        assert!(
+            under.contains_key("api"),
+            "portal filed against the main worktree should be found under a sibling worktree"
+        );
+
+        let at = find_portals_at(&config, &feature_services_dir);
+        assert!(
+            at.contains_key("api"),
+            "portal filed against the main worktree should be found at the equivalent path in a sibling worktree"
+        );
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -193,6 +193,29 @@ fn find_portals_under(config: &Config, dir: &Path) -> std::collections::BTreeMap
     }
 }
 
+/// Find portals located at exactly `dir` (worktree-aware): a portal in a
+/// different worktree of the same repo as `dir`, at the equivalent
+/// relative path, counts as being here too.
+fn find_portals_at(config: &Config, dir: &Path) -> std::collections::BTreeMap<String, String> {
+    match worktree_location(dir) {
+        Some((worktrees, cwd_rel)) => config
+            .portals
+            .iter()
+            .filter(|(_, path)| {
+                relative_location(&resolve::expand_tilde(path), &worktrees)
+                    .is_some_and(|rel| rel == cwd_rel)
+            })
+            .map(|(name, path)| (name.clone(), path.clone()))
+            .collect(),
+        None => config
+            .portals
+            .iter()
+            .filter(|(_, path)| resolve::expand_tilde(path) == *dir)
+            .map(|(name, path)| (name.clone(), path.clone()))
+            .collect(),
+    }
+}
+
 fn cmd_teleport(config: &Config, query: &str, mode: NavMode, claude: bool) {
     if let Some(path) = config.portals.get(query) {
         teleport_to_portal(query, path, mode, claude);
@@ -666,6 +689,52 @@ mod tests {
 
         let dir = resolve::expand_tilde("~/code/monorepo");
         let matches = find_portals_under(&config, &dir);
+
+        assert_eq!(matches.len(), 1);
+        assert!(matches.contains_key("api"));
+    }
+
+    #[test]
+    fn find_portals_at_matches_exact_path() {
+        let mut config = Config::default();
+        config.portals.insert("monorepo".to_string(), "/home/jeff/code/monorepo".to_string());
+
+        let dir = Path::new("/home/jeff/code/monorepo");
+        let matches = find_portals_at(&config, dir);
+
+        assert_eq!(matches.len(), 1);
+        assert!(matches.contains_key("monorepo"));
+    }
+
+    #[test]
+    fn find_portals_at_excludes_strict_subdir() {
+        let mut config = Config::default();
+        config.portals.insert("api".to_string(), "/home/jeff/code/monorepo/services/api".to_string());
+
+        let dir = Path::new("/home/jeff/code/monorepo");
+        let matches = find_portals_at(&config, dir);
+
+        assert!(matches.is_empty());
+    }
+
+    #[test]
+    fn find_portals_at_no_match_for_unrelated_dir() {
+        let mut config = Config::default();
+        config.portals.insert("notes".to_string(), "/home/jeff/Documents/notes".to_string());
+
+        let dir = Path::new("/home/jeff/code/monorepo");
+        let matches = find_portals_at(&config, dir);
+
+        assert!(matches.is_empty());
+    }
+
+    #[test]
+    fn find_portals_at_resolves_tilde_paths() {
+        let mut config = Config::default();
+        config.portals.insert("api".to_string(), "~/code/monorepo".to_string());
+
+        let dir = resolve::expand_tilde("~/code/monorepo");
+        let matches = find_portals_at(&config, &dir);
 
         assert_eq!(matches.len(), 1);
         assert!(matches.contains_key("api"));

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,7 +61,7 @@ struct Cli {
     #[arg(short = 'c', long = "claude", conflicts_with_all = ["add", "remove", "list", "edit", "prune"])]
     claude: bool,
 
-    /// Portal name, teleport query, or "." for the current repo's worktree picker
+    /// Portal name, teleport query, "." for the current repo's worktree picker, or a directory to list portals at with -l
     name: Option<String>,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -216,6 +216,22 @@ fn find_portals_at(config: &Config, dir: &Path) -> std::collections::BTreeMap<St
     }
 }
 
+/// Resolve a `-l` location argument to an absolute directory: `.` means the
+/// current directory; anything else is tilde-expanded and, if still
+/// relative, joined onto `cwd`.
+fn resolve_location_arg(cwd: &Path, arg: &str) -> PathBuf {
+    if arg == "." {
+        return cwd.to_path_buf();
+    }
+
+    let expanded = resolve::expand_tilde(arg);
+    if expanded.is_absolute() {
+        expanded
+    } else {
+        cwd.join(expanded)
+    }
+}
+
 fn cmd_teleport(config: &Config, query: &str, mode: NavMode, claude: bool) {
     if let Some(path) = config.portals.get(query) {
         teleport_to_portal(query, path, mode, claude);
@@ -738,6 +754,33 @@ mod tests {
 
         assert_eq!(matches.len(), 1);
         assert!(matches.contains_key("api"));
+    }
+
+    #[test]
+    fn resolve_location_arg_dot_is_cwd() {
+        let cwd = PathBuf::from("/home/jeff/code/monorepo");
+        assert_eq!(resolve_location_arg(&cwd, "."), cwd);
+    }
+
+    #[test]
+    fn resolve_location_arg_absolute_path_passes_through() {
+        let cwd = PathBuf::from("/home/jeff/code/monorepo");
+        let result = resolve_location_arg(&cwd, "/etc/hosts");
+        assert_eq!(result, PathBuf::from("/etc/hosts"));
+    }
+
+    #[test]
+    fn resolve_location_arg_expands_tilde() {
+        let cwd = PathBuf::from("/home/jeff/code/monorepo");
+        let result = resolve_location_arg(&cwd, "~/Documents/notes");
+        assert_eq!(result, resolve::expand_tilde("~/Documents/notes"));
+    }
+
+    #[test]
+    fn resolve_location_arg_joins_relative_onto_cwd() {
+        let cwd = PathBuf::from("/home/jeff/code/monorepo");
+        let result = resolve_location_arg(&cwd, "services/api");
+        assert_eq!(result, PathBuf::from("/home/jeff/code/monorepo/services/api"));
     }
 
     fn git_test(repo: &std::path::Path, args: &[&str]) {

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -79,6 +79,44 @@ pub fn git_worktree_list(repo_path: &Path) -> Vec<PathBuf> {
         .collect()
 }
 
+/// List a repo's worktrees, skipping the `git worktree list` call entirely
+/// when the repo has no linked worktrees (only the one at `toplevel`).
+fn worktrees_for_toplevel(toplevel: &Path) -> Vec<PathBuf> {
+    let git_path = toplevel.join(".git");
+    let may_have_worktrees = if git_path.is_dir() {
+        git_path
+            .join("worktrees")
+            .read_dir()
+            .is_ok_and(|mut d| d.next().is_some())
+    } else {
+        true
+    };
+
+    if may_have_worktrees {
+        git_worktree_list(toplevel)
+    } else {
+        vec![toplevel.to_path_buf()]
+    }
+}
+
+/// Get the worktree list for whatever repo contains `dir`, or `None` if
+/// `dir` isn't inside a git repo. `git_toplevel_for` returns the toplevel of
+/// whichever worktree `dir` is actually in, so this works the same whether
+/// `dir` is in the main worktree or a linked one.
+pub fn repo_worktrees_for(dir: &Path) -> Option<Vec<PathBuf>> {
+    let toplevel = git_toplevel_for(dir)?;
+    Some(worktrees_for_toplevel(&toplevel))
+}
+
+/// Find the worktree (if any) that contains `path`, and `path`'s location
+/// relative to that worktree's root.
+pub fn relative_to_worktree(path: &Path, worktrees: &[PathBuf]) -> Option<(PathBuf, PathBuf)> {
+    worktrees
+        .iter()
+        .find(|wt| path.starts_with(wt))
+        .map(|wt| (wt.clone(), path.strip_prefix(wt).unwrap().to_path_buf()))
+}
+
 /// Context for resolving a portal that lives inside a git repo.
 pub struct PortalContext {
     pub worktrees: Vec<PathBuf>,
@@ -101,22 +139,7 @@ pub fn portal_worktree_context(portal_path: &str) -> Option<PortalContext> {
         _ => String::new(),
     };
 
-    // Only spawn `git worktree list` if the repo actually uses worktrees.
-    let git_path = toplevel.join(".git");
-    let may_have_worktrees = if git_path.is_dir() {
-        git_path
-            .join("worktrees")
-            .read_dir()
-            .is_ok_and(|mut d| d.next().is_some())
-    } else {
-        true
-    };
-
-    let worktrees = if may_have_worktrees {
-        git_worktree_list(&toplevel)
-    } else {
-        vec![toplevel.clone()]
-    };
+    let worktrees = worktrees_for_toplevel(&toplevel);
 
     let main_wt = worktrees.first().cloned().unwrap_or_else(|| toplevel.clone());
 
@@ -264,5 +287,57 @@ mod tests {
         assert_eq!(sorted[0].path, main);
         assert!(sorted[0].is_main);
         assert!(!sorted[0].is_current);
+    }
+
+    #[test]
+    fn relative_to_worktree_root_is_empty() {
+        let wt = PathBuf::from("/repo");
+        let worktrees = vec![wt.clone()];
+
+        let (root, rel) = relative_to_worktree(&wt, &worktrees).unwrap();
+
+        assert_eq!(root, wt);
+        assert_eq!(rel, PathBuf::new());
+    }
+
+    #[test]
+    fn relative_to_worktree_nested_subdir() {
+        let wt = PathBuf::from("/repo");
+        let worktrees = vec![wt.clone()];
+        let path = PathBuf::from("/repo/services/api");
+
+        let (root, rel) = relative_to_worktree(&path, &worktrees).unwrap();
+
+        assert_eq!(root, wt);
+        assert_eq!(rel, PathBuf::from("services/api"));
+    }
+
+    #[test]
+    fn relative_to_worktree_picks_containing_worktree() {
+        let main = PathBuf::from("/repo");
+        let feature = PathBuf::from("/repo.feature-oauth");
+        let worktrees = vec![main, feature.clone()];
+        let path = PathBuf::from("/repo.feature-oauth/services/api");
+
+        let (root, rel) = relative_to_worktree(&path, &worktrees).unwrap();
+
+        assert_eq!(root, feature);
+        assert_eq!(rel, PathBuf::from("services/api"));
+    }
+
+    #[test]
+    fn relative_to_worktree_none_when_unrelated() {
+        let worktrees = vec![PathBuf::from("/repo")];
+        let path = PathBuf::from("/elsewhere/api");
+
+        assert!(relative_to_worktree(&path, &worktrees).is_none());
+    }
+
+    #[test]
+    fn relative_to_worktree_no_false_positive_on_shared_prefix() {
+        let worktrees = vec![PathBuf::from("/repo")];
+        let path = PathBuf::from("/repo2/api");
+
+        assert!(relative_to_worktree(&path, &worktrees).is_none());
     }
 }


### PR DESCRIPTION
## Summary

Closes #54.

- `-u`/`--under` is now worktree-aware: a portal filed against one worktree of a repo is now correctly recognized as being under a directory in a *different* worktree of the same repo. Its existing semantics (strict descendants only, exact cwd match excluded) are otherwise unchanged.
- `-l` gains an optional directory argument: `tp -l <dir>` (e.g. `tp -l .`) lists portals located at exactly that directory, worktree-aware. `tp -l` with no argument still lists everything.

No new flag was added, and `tp -a` is unchanged — see `specs/2026-07-29-portal-here-lookup-design.md` for the fuller design rationale, including two alternative designs that were considered and rejected.

## Test plan

- [x] `cargo test` — 70/70 passing, including a real `git init` + `git worktree add` integration test proving the cross-worktree matching
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] Manual smoke test of `tp -l .` and `tp -l <nonexistent path>` against a real config
- [x] Independent whole-branch review (spec alignment, cross-task integration, architecture, docs accuracy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)